### PR TITLE
use TLS v1.2 for DefaultSpringHttpClientFactory

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/httpclient/DefaultSpringHttpClientFactory.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/httpclient/DefaultSpringHttpClientFactory.java
@@ -88,7 +88,7 @@ public class DefaultSpringHttpClientFactory implements SpringHttpClientFactory {
 						.setMaxConnPerRoute(MAX_CONNECTIONS_PER_ROUTE)
 						.setMaxConnTotal(MAX_CONNECTIONS)
 						.setSSLSocketFactory(SSLConnectionSocketFactoryBuilder.create()
-								.setTlsVersions(TLS.V_1_3)
+								.setTlsVersions(TLS.V_1_2) // TLS 1.3 not yet supported by cf routing
 								.setSslContext(context)
 								.build())
 						.build());


### PR DESCRIPTION
Fixes supported certificate protocol version mismatch with cf routing in spring-xsuaa module. Version 1.3 is not yet supported.