### PR TITLE
Restore support for multiple XSUAA Application Plan service bindings

### DIFF
--- a/env/src/main/java/com/sap/cloud/security/config/ServiceBindingEnvironment.java
+++ b/env/src/main/java/com/sap/cloud/security/config/ServiceBindingEnvironment.java
@@ -74,7 +74,7 @@ public class ServiceBindingEnvironment implements Environment {
 	 * <li>BROKER</li>
 	 * <li>SPACE</li>
 	 * <li>DEFAULT</li>
-	 * <li><other or missing plan></li>
+	 * <li>&lt;other or missing plan&gt;</li>
 	 * </ul>
 	 */
 	@Nullable

--- a/env/src/main/java/com/sap/cloud/security/config/ServiceBindingEnvironment.java
+++ b/env/src/main/java/com/sap/cloud/security/config/ServiceBindingEnvironment.java
@@ -146,7 +146,7 @@ public class ServiceBindingEnvironment implements Environment {
 			this.readServiceConfigurations();
 		}
 
-		Map<Service, Map<ServiceConstants.Plan, OAuth2ServiceConfiguration>> result = new HashMap<>();
+		Map<Service, Map<ServiceConstants.Plan, OAuth2ServiceConfiguration>> result = new EnumMap<>(Service.class);
 
 		for (Map.Entry<Service, List<OAuth2ServiceConfiguration>> entry : serviceConfigurations.entrySet()) {
 			Service service = entry.getKey();

--- a/env/src/main/java/com/sap/cloud/security/config/ServiceBindingEnvironment.java
+++ b/env/src/main/java/com/sap/cloud/security/config/ServiceBindingEnvironment.java
@@ -73,7 +73,6 @@ public class ServiceBindingEnvironment implements Environment {
 	 * <li>BROKER</li>
 	 * <li>SPACE</li>
 	 * <li>DEFAULT</li>
-	 * <li>&lt;other or missing plan&gt;</li>
 	 * </ul>
 	 */
 	@Nullable
@@ -87,7 +86,7 @@ public class ServiceBindingEnvironment implements Environment {
 		return xsuaaConfigurations.stream()
 				.filter(config -> planOrder.contains(getConfigPlan.apply(config)))
 				.min(Comparator.comparingInt(config -> planOrder.indexOf(getConfigPlan.apply(config))))
-				.orElseGet(() -> xsuaaConfigurations.stream().findFirst().orElse(null));
+				.orElse(null);
 	}
 
 	@Override

--- a/env/src/main/java/com/sap/cloud/security/config/ServiceBindingEnvironment.java
+++ b/env/src/main/java/com/sap/cloud/security/config/ServiceBindingEnvironment.java
@@ -12,7 +12,6 @@ import com.sap.cloud.security.json.DefaultJsonObject;
 
 import javax.annotation.Nullable;
 import java.util.*;
-import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -136,32 +135,14 @@ public class ServiceBindingEnvironment implements Environment {
 	 * Gives access to all service configurations parsed from the environment. The
 	 * service configurations are parsed on the first access, then cached.
 	 *
-	 * Note that the result only contains one service configuration per service plan.
-	 * If you use multiple identical service plans, you can use {@link ServiceBindingEnvironment#getServiceConfigurationsAsList()}
-	 * to get all configurations or use {@link ServiceBindingEnvironment#getServiceConfigurationsAsList()} with a custom merge function
-	 * to decide which configuration to return for each plan.
+	 * Note that the result contains only one service configuration per service plan.
+	 * If you use multiple identical service plans, and you need to access a specific configuration, use
+	 * {@link ServiceBindingEnvironment#getServiceConfigurationsAsList()} to get a complete list of configurations.
 	 *
-	 * @return the service configurations grouped first by service, then by service
-	 *         plan.
+	 * @return the service configurations grouped first by service, then by service plan.
 	 */
 	@Override
 	public Map<Service, Map<ServiceConstants.Plan, OAuth2ServiceConfiguration>> getServiceConfigurations() {
-		return getServiceConfigurations((a, b) -> a);
-	}
-
-	/**
-	 * Gives access to all service configurations parsed from the environment. The
-	 * service configurations are parsed on the first access, then cached.
-	 *
-	 * Note that this method only contains one service configuration per service plan.
-	 * To decide which configuration to return for each service plan when more than one configuration
-	 * with the same service plan is found, the given merge function is used to resolves collisions.
-	 *
-	 * @return the service configurations grouped first by service, then by service
-	 *         plan.
-	 */
-	public Map<Service, Map<ServiceConstants.Plan, OAuth2ServiceConfiguration>> getServiceConfigurations(
-			BinaryOperator<OAuth2ServiceConfiguration> servicePlanMerger) {
 		if (serviceConfigurations == null) {
 			this.readServiceConfigurations();
 		}
@@ -176,7 +157,7 @@ public class ServiceBindingEnvironment implements Environment {
 					.collect(Collectors.toMap(
 							config -> ServiceConstants.Plan.from(config.getProperty(SERVICE_PLAN)),
 							Function.identity(),
-							servicePlanMerger
+							(a, b) -> a
 					));
 
 			result.put(service, planConfigurations);

--- a/env/src/main/java/com/sap/cloud/security/config/ServiceBindingEnvironment.java
+++ b/env/src/main/java/com/sap/cloud/security/config/ServiceBindingEnvironment.java
@@ -135,7 +135,7 @@ public class ServiceBindingEnvironment implements Environment {
 	 * service configurations are parsed on the first access, then cached.
 	 *
 	 * Note that the result contains only one service configuration per service plan and does not contain configurations
-	 * with a service plan other than those from {@link ServiceConstants#Plan}.
+	 * with a service plan other than those from {@link ServiceConstants}#Plan.
 	 * Use {@link ServiceBindingEnvironment#getServiceConfigurationsAsList()} to get a complete list of configurations.
 	 *
 	 * @return the service configurations grouped first by service, then by service plan.

--- a/env/src/test/java/com/sap/cloud/security/config/ServiceBindingEnvironmentTest.java
+++ b/env/src/test/java/com/sap/cloud/security/config/ServiceBindingEnvironmentTest.java
@@ -133,36 +133,6 @@ class ServiceBindingEnvironmentTest {
 	}
 
 	@Test
-	void getServiceConfigurationsWithPlanMerger() {
-		Map<Service, Map<ServiceConstants.Plan, OAuth2ServiceConfiguration>> configs = cutIas
-				.getServiceConfigurations((a, b) -> a);
-		assertThat(configs.get(Service.XSUAA).entrySet(), is((empty())));
-		assertThat(configs.get(Service.IAS).entrySet(), hasSize(1));
-
-		configs = cutXsuaa.getServiceConfigurations((a, b) -> a);
-		assertThat(configs.get(Service.XSUAA).entrySet(), hasSize(1));
-		assertThat(configs.get(Service.IAS).entrySet(), is(empty()));
-
-		configs = cutMultipleXsuaa.getServiceConfigurations((a, b) -> a);
-		assertThat(configs.get(Service.XSUAA).entrySet(), hasSize(2));
-		assertThat(configs.get(Service.IAS).entrySet(), is(empty()));
-		assertNotNull(configs.get(Service.XSUAA).get(ServiceConstants.Plan.BROKER));
-		assertNotNull(configs.get(Service.XSUAA).get(ServiceConstants.Plan.APPLICATION));
-
-		configs = cutMultipleApplicationPlanXsuaa.getServiceConfigurations((a, b) -> a);
-		assertThat(configs.get(Service.XSUAA).entrySet(), hasSize(2));
-		assertThat(configs.get(Service.IAS).entrySet(), is(empty()));
-		assertNotNull(configs.get(Service.XSUAA).get(ServiceConstants.Plan.BROKER));
-		assertNotNull(configs.get(Service.XSUAA).get(ServiceConstants.Plan.APPLICATION));
-
-		configs = cutMultipleApplicationPlanXsuaa.getServiceConfigurations((a, b) ->
-				"https://api2.uaadomain.org".equals((a.getProperty(ServiceConstants.XSUAA.API_URL))) ? a : b
-		);
-		assertEquals(configs.get(Service.XSUAA).get(ServiceConstants.Plan.APPLICATION).getProperty(ServiceConstants.XSUAA.API_URL),
-				"https://api2.uaadomain.org");
-	}
-
-	@Test
 	void getConfigurationOfXsuaaInstanceInXsaSystem() {
 		ServiceBindingEnvironment cut = new ServiceBindingEnvironment(
 				new SapVcapServicesServiceBindingAccessor(any -> vcapXsa))

--- a/env/src/test/java/com/sap/cloud/security/config/ServiceBindingEnvironmentTest.java
+++ b/env/src/test/java/com/sap/cloud/security/config/ServiceBindingEnvironmentTest.java
@@ -56,7 +56,7 @@ class ServiceBindingEnvironmentTest {
 	void getXsuaaConfiguration() {
 		assertNull(cutIas.getXsuaaConfiguration());
 		assertNotNull(cutXsuaa.getXsuaaConfiguration());
-		assertNotNull(cutUnknownServicePlanXsuaa.getXsuaaConfiguration());
+		assertNull(cutUnknownServicePlanXsuaa.getXsuaaConfiguration());
 		assertEquals(Service.XSUAA, cutXsuaa.getXsuaaConfiguration().getService());
 		assertThat(cutMultipleXsuaa.getXsuaaConfiguration().getProperty(ServiceConstants.SERVICE_PLAN),
 				equalToIgnoringCase(ServiceConstants.Plan.APPLICATION.toString()));
@@ -143,7 +143,8 @@ class ServiceBindingEnvironmentTest {
 		assertNotNull(configs.get(Service.XSUAA).get(ServiceConstants.Plan.APPLICATION));
 
 		configs = cutUnknownServicePlanXsuaa.getServiceConfigurations();
-		assertThat(configs.get(Service.XSUAA).entrySet(), hasSize(1));
+		assertThat(configs.get(Service.XSUAA).entrySet(), hasSize(0));
+		assertThat(cutUnknownServicePlanXsuaa.getServiceConfigurationsAsList().get(Service.XSUAA), hasSize(1));
 	}
 
 	@Test

--- a/env/src/test/java/com/sap/cloud/security/config/ServiceBindingEnvironmentTest.java
+++ b/env/src/test/java/com/sap/cloud/security/config/ServiceBindingEnvironmentTest.java
@@ -144,7 +144,6 @@ class ServiceBindingEnvironmentTest {
 
 		configs = cutUnknownServicePlanXsuaa.getServiceConfigurations();
 		assertThat(configs.get(Service.XSUAA).entrySet(), hasSize(0));
-		assertThat(cutUnknownServicePlanXsuaa.getServiceConfigurationsAsList().get(Service.XSUAA), hasSize(1));
 	}
 
 	@Test

--- a/env/src/test/resources/vcapXsuaaServiceMultipleApplicationPlanBindings.json
+++ b/env/src/test/resources/vcapXsuaaServiceMultipleApplicationPlanBindings.json
@@ -1,0 +1,88 @@
+{
+  "xsuaa": [
+    {
+      "binding_name": null,
+      "credentials": {
+        "apiurl": "https://api.uaadomain.org",
+        "certificate": "",
+        "key": "",
+        "clientid": "sb-xsuaa-broker!b8066",
+        "clientsecret": "sppEXArNzp3tccATO99CZsRKESY=",
+        "identityzone": "id-test-zone",
+        "identityzoneid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "sburl": "https://internal-xsuaa.uaadomain.org",
+        "tenantid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "tenantmode": "dedicated",
+        "trustedclientidsuffix": "|xsuaa-broker!b8066",
+        "uaadomain": "uaadomain.org",
+        "url": "https://id-test-zone.uaadomain.org",
+        "verificationkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAABBBQ8AMIIBCgKCAQEAx/jN5v1mp/TVn9nTQoYVIUfCsUDHa3Upr5tDZC7mzlTrN2PnwruzyS7w1Jd+StqwW4/vn87ua2YlZzU8Ob0jR4lbOPCKaHIi0kyNtJXQvQ7LZPG8epQLbx0IIP/WLVVVtB8bL5OWuHma3pUnibbmATtbOh5LksQ2zLMngEjUF52JQyzTpjoQkahp0BNe/drlAqO253keiY63FL6belKjJGmSqdnotSXxB2ym+HQ0ShaNvTFLEvi2+ObkyjGWgFpQaoCcGq0KX0y0mPzOvdFsNT+rBFdkHiK+Jl638Sbim1z9fItFbH9hiVwY37R9rLtH1YKi3PuATMjf/DJ7mUluDQIDAQAB-----END PUBLIC KEY-----",
+        "xsappname": "xsuaa-broker!b8066"
+      },
+      "instance_name": "xsuaa-broker",
+      "label": "xsuaa",
+      "name": "xsuaa-broker",
+      "plan": "broker",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "xsuaa"
+      ],
+      "volume_mounts": []
+    },
+    {
+      "binding_name": null,
+      "credentials": {
+        "apiurl": "https://api.uaadomain.org",
+        "clientid": "sb-na-d6a3278d-5e07-40e9-92ae-546bbfd9cdde!t8066",
+        "clientsecret": "1idLRlbbb9oextvpmS6bfpQXLk=",
+        "identityzone": "id-test-zone",
+        "identityzoneid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "sburl": "https://internal-xsuaa.uaadomain.org",
+        "tenantid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "tenantmode": "shared",
+        "uaadomain": "uaadomain.org",
+        "url": "https://id-test-zone.uaadomain.org",
+        "verificationkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAABBBQ8AMIIBCgKCAQEAx/jN5v1mp/TVn9nTQoYVIUfCsUDHa3Upr5tDZC7mzlTrN2PnwruzyS7w1Jd+StqwW4/vn87ua2YlZzU8Ob0jR4lbOPCKaHIi0kyNtJXQvQ7LZPG8epQLbx0IIP/WLVVVtB8bL5OWuHma3pUnibbmATtbOh5LksQ2zLMngEjUF52JQyzTpjoQkahp0BNe/drlAqO253keiY63FL6belKjJGmSqdnotSXxB2ym+HQ0ShaNvTFLEvi2+ObkyjGWgFpQaoCcGq0KX0y0mPzOvdFsNT+rBFdkHiK+Jl638Sbim1z9fItFbH9hiVwY37R9rLtH1YKi3PuATMjf/DJ7mUluDQIDAQAB-----END PUBLIC KEY-----",
+        "xsappname": "na-d6a3278d-5e07-40e9-92ae-546bbfd9cdde!t8066"
+      },
+      "instance_name": "xsuaa-app",
+      "label": "xsuaa",
+      "name": "xsuaa-app",
+      "plan": "application",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "xsuaa"
+      ],
+      "volume_mounts": []
+    },
+    {
+      "binding_name": null,
+      "credentials": {
+        "apiurl": "https://api2.uaadomain.org",
+        "clientid": "sb-na-d6a3278d-5e07-40e9-92ae-546bbfd9cdde!t8067",
+        "clientsecret": "1idLRlbbb9oextvpmS6bfpQXLk=",
+        "identityzone": "id-test-zone",
+        "identityzoneid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "sburl": "https://internal-xsuaa.uaadomain.org",
+        "tenantid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "tenantmode": "shared",
+        "uaadomain": "uaadomain.org",
+        "url": "https://id-test-zone.uaadomain.org",
+        "verificationkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAABBBQ8AMIIBCgKCAQEAx/jN5v1mp/TVn9nTQoYVIUfCsUDHa3Upr5tDZC7mzlTrN2PnwruzyS7w1Jd+StqwW4/vn87ua2YlZzU8Ob0jR4lbOPCKaHIi0kyNtJXQvQ7LZPG8epQLbx0IIP/WLVVVtB8bL5OWuHma3pUnibbmATtbOh5LksQ2zLMngEjUF52JQyzTpjoQkahp0BNe/drlAqO253keiY63FL6belKjJGmSqdnotSXxB2ym+HQ0ShaNvTFLEvi2+ObkyjGWgFpQaoCcGq0KX0y0mPzOvdFsNT+rBFdkHiK+Jl638Sbim1z9fItFbH9hiVwY37R9rLtH1YKi3PuATMjf/DJ7mUluDQIDAQAB-----END PUBLIC KEY-----",
+        "xsappname": "na-d6a3278d-5e07-40e9-92ae-546bbfd9cdde!t8067"
+      },
+      "instance_name": "xsuaa-app2",
+      "label": "xsuaa",
+      "name": "xsuaa-app2",
+      "plan": "application",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "xsuaa"
+      ],
+      "volume_mounts": []
+    }
+  ]
+}

--- a/java-security/README.md
+++ b/java-security/README.md
@@ -1,6 +1,6 @@
 # SAP BTP Java Security Client Library
 
-This library provides a Token Validation utility for Java EE applications. Tokens issued by SAP BTP Identity service and Xsuaa services are supported. Moreover, Identity tokens issued by multiple tenants can also be validated.
+This library provides a Token Validation utility for Jakarta EE applications. Tokens issued by SAP BTP Identity service and Xsuaa services are supported. Moreover, Identity tokens issued by multiple tenants can also be validated.
 
 To be able to validate tokens it performs the following tasks:
 - Loads Identity Service Configuration from `VCAP_SERVICES` in Cloud Foundry or from secrets in Kubernetes environment into the [`OAuth2ServiceConfiguration`](/java-api/src/main/java/com/sap/cloud/security/config/OAuth2ServiceConfiguration.java). The [`Environments`](/env/src/main/java/com/sap/cloud/security/config/Environments.java) serves as central entry point to get access to the `OAuth2ServiceConfiguration`.

--- a/java-security/README.md
+++ b/java-security/README.md
@@ -40,7 +40,7 @@ To be able to validate tokens it performs the following tasks:
 ## Requirements
 - Java 17
 - [Apache HttpClient 4.5](https://hc.apache.org/httpcomponents-client-4.5.x/index.html)
-- Tomcat 10 or any other servlet that supports Jakarta API
+- Tomcat 10 or any other servlet that implements specification of the Jakarta EE platform
 
 ## Table of Contents
 1. [Setup](#setup)


### PR DESCRIPTION
I changed ServiceBindingEnvironment to store service configurations as list instead of mapped by service plan.

In order to not break the existing public API for getting service configurations as a Map, I added ServiceBindingEnvironment#getServiceConfigurationsAsList as an alternative that returns all configurations