### PR TITLE
expose http status code in OAuth2ServiceException

### DIFF
--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2ServiceException.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2ServiceException.java
@@ -37,6 +37,16 @@ public class OAuth2ServiceException extends IOException {
 		super(message);
 		this.httpStatusCode = httpStatusCode != null ? httpStatusCode : 0;
 	}
+	
+	/**
+	 * Returns the HTTP status code of the failed OAuth2 service request or
+	 * {@code 0} e.g. in case the service wasn't called at all.
+	 *
+	 * @return status code or 0
+	 */
+	public Integer getHttpStatusCode() {
+		return httpStatusCode;
+	}
 
 	/**
 	 * Creates an exception.

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultOidcConfigurationServiceTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultOidcConfigurationServiceTest.java
@@ -93,7 +93,8 @@ public class DefaultOidcConfigurationServiceTest {
 		assertThatThrownBy(this::retrieveEndpoints)
 				.isInstanceOf(OAuth2ServiceException.class)
 				.hasMessageContaining(errorMessage)
-				.extracting("httpStatusCode").isEqualTo(0);
+				.extracting(OAuth2ServiceException.class::cast)
+				.extracting(OAuth2ServiceException::getHttpStatusCode).isEqualTo(0);
 	}
 
 	@Test


### PR DESCRIPTION
Expose the `httpStatusCode` field from `OAuth2ServiceException`.

It has been like this before, but the method had been removed in #1179.
If there is no reason not to expose it to the caller, we would like to have it back as our current code is relying on it for error handling.