### PR TITLE
Add x-app_tid and x-client_id headers only when both are availabe

### DIFF
--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenKeyService.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenKeyService.java
@@ -8,6 +8,7 @@ package com.sap.cloud.security.xsuaa.client;
 import com.sap.cloud.security.client.HttpClientFactory;
 import com.sap.cloud.security.xsuaa.Assertions;
 import com.sap.cloud.security.xsuaa.util.HttpClientUtil;
+import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
@@ -22,6 +23,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import static com.sap.cloud.security.xsuaa.http.HttpHeaders.X_APP_TID;
 import static com.sap.cloud.security.xsuaa.http.HttpHeaders.X_CLIENT_ID;
@@ -52,10 +54,8 @@ public class DefaultOAuth2TokenKeyService implements OAuth2TokenKeyService {
 		Assertions.assertNotNull(tokenKeysEndpointUri, "Token key endpoint must not be null!");
 		HttpUriRequest request = new HttpGet(tokenKeysEndpointUri); // lgtm[java/ssrf] tokenKeysEndpointUri is validated
 																	// as part of XsuaaJkuValidator in java-security
-		if (tenantId != null) {
+		if (tenantId != null && clientId != null) {
 			request.addHeader(X_APP_TID, tenantId);
-		}
-		if (clientId != null){
 			request.addHeader(X_CLIENT_ID, clientId);
 		}
 		request.addHeader(HttpHeaders.USER_AGENT, HttpClientUtil.getUserAgent());
@@ -68,9 +68,10 @@ public class DefaultOAuth2TokenKeyService implements OAuth2TokenKeyService {
 				LOGGER.debug("Received statusCode {}", statusCode);
 				String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
 				if (statusCode != HttpStatus.SC_OK) {
-					throw OAuth2ServiceException.builder("Error retrieving token keys for x-app_tid " + tenantId)
+					throw OAuth2ServiceException.builder("Error retrieving token keys. Request headers " + Arrays.stream(request.getAllHeaders()).toList())
 							.withUri(tokenKeysEndpointUri)
-							.withHeaders(X_APP_TID + "=" + tenantId + ", " +  X_CLIENT_ID + "=" +  clientId)
+							.withHeaders(response.getAllHeaders() != null ?
+									Arrays.stream(response.getAllHeaders()).map(Header::toString).toArray(String[]::new) : null)
 							.withStatusCode(statusCode)
 							.withResponseBody(body)
 							.build();
@@ -80,7 +81,11 @@ public class DefaultOAuth2TokenKeyService implements OAuth2TokenKeyService {
 				return body;
 			});
 		} catch (IOException e) {
-			throw new OAuth2ServiceException("Error retrieving token keys: " + e.getMessage());
+			if (e instanceof OAuth2ServiceException oAuth2Exception) {
+				throw oAuth2Exception;
+			} else {
+				throw new OAuth2ServiceException("Error retrieving token keys: " + e.getMessage());
+			}
 		}
 	}
 

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenService.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenService.java
@@ -10,6 +10,7 @@ import com.sap.cloud.security.xsuaa.Assertions;
 import com.sap.cloud.security.xsuaa.http.HttpHeaders;
 import com.sap.cloud.security.xsuaa.tokenflows.TokenCacheConfiguration;
 import com.sap.cloud.security.xsuaa.util.HttpClientUtil;
+import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
@@ -95,7 +96,9 @@ public class DefaultOAuth2TokenService extends AbstractOAuth2TokenService {
 				throw OAuth2ServiceException.builder("Error retrieving JWT token")
 						.withStatusCode(statusCode)
 						.withUri(requestUri)
-						.withHeaders(Arrays.toString(response.getAllHeaders()))
+						.withHeaders(response.getAllHeaders() != null ? Arrays.stream(response.getAllHeaders()).map(
+										Header::toString)
+								.toArray(String[]::new) : null)
 						.withResponseBody(body)
 						.build();
 			}

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2ServiceException.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2ServiceException.java
@@ -151,7 +151,7 @@ public class OAuth2ServiceException extends IOException {
 		}
 
 		private String createHeaderMessage() {
-			return headersString == null ? null : "Headers " + headersString;
+			return headersString == null ? null : "Response Headers " + headersString;
 		}
 	}
 }

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenKeyServiceTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenKeyServiceTest.java
@@ -23,7 +23,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.times;
@@ -68,9 +70,34 @@ public class DefaultOAuth2TokenKeyServiceTest {
 		assertThatThrownBy(() -> cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, APP_TID, CLIENT_ID))
 				.isInstanceOf(OAuth2ServiceException.class)
 				.hasMessageContaining(errorDescription)
+				.hasMessageContaining("Request headers [x-app_tid: 92768714-4c2e-4b79-bc1b-009a4127ee3c, x-client_id: client-id, User-Agent: token-client/3.1.2]")
 				.hasMessageContaining("'Something went wrong'")
 				.hasMessageContaining("Error retrieving token keys")
-				.hasMessageContaining("Headers [x-app_tid=92768714-4c2e-4b79-bc1b-009a4127ee3c, x-client_id=client-id]");
+				.hasMessageContaining("Response Headers [testHeader: testValue]")
+				.hasMessageContaining("Http status code 400");
+	}
+
+	@Test
+	public void retrieveTokenKeys_responseNotOk_throwsException_noAppTid() throws IOException {
+		String errorDescription = "Something went wrong";
+		CloseableHttpResponse response = HttpClientTestFactory
+				.createHttpResponse(errorDescription, HttpStatus.SC_BAD_REQUEST);
+		when(httpClient.execute(any(), any(ResponseHandler.class))).thenAnswer(invocation -> {
+			ResponseHandler responseHandler = invocation.getArgument(1);
+			return responseHandler.handleResponse(response);
+		});
+
+		OAuth2ServiceException e = assertThrows(OAuth2ServiceException.class,
+				() -> cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, null, CLIENT_ID));
+
+		assertThat(e.getHeaders()).contains("testHeader: testValue");
+		assertThat(e.getHttpStatusCode()).isEqualTo(400);
+		assertThat(e.getMessage())
+				.contains(errorDescription)
+				.contains("Request headers [User-Agent: token-client/3.1.2].")
+				.contains("Response Headers [testHeader: testValue]")
+				.contains("Http status code 400")
+				.contains("Server URI https://tokenKeys.io/token_keys");
 	}
 
 	@Test

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenServiceTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenServiceTest.java
@@ -5,19 +5,6 @@
  */
 package com.sap.cloud.security.xsuaa.client;
 
-import static com.sap.cloud.security.servlet.MDCHelper.CORRELATION_ID;
-import static java.util.Collections.emptyMap;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-
-import java.io.IOException;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.util.Map;
-
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -43,6 +30,20 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Map;
+
+import static com.sap.cloud.security.servlet.MDCHelper.CORRELATION_ID;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultOAuth2TokenServiceTest {
@@ -146,11 +147,14 @@ public class DefaultOAuth2TokenServiceTest {
 			return responseHandler.handleResponse(response);
 		});
 
-		assertThatThrownBy(() -> requestAccessToken(emptyMap()))
-				.isInstanceOf(OAuth2ServiceException.class)
-				.hasMessageContaining(unauthorizedResponseText)
-				.hasMessageContaining(TOKEN_ENDPOINT_URI.toString())
-				.extracting("httpStatusCode").isEqualTo(HttpStatus.SC_UNAUTHORIZED);
+		OAuth2ServiceException e = assertThrows(OAuth2ServiceException.class,
+				() -> requestAccessToken(emptyMap()));
+
+		assertThat(e.getHeaders().get(0)).isEqualTo("testHeader: testValue");
+		assertThat(e.getHttpStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
+		assertThat(e.getMessage())
+				.contains(unauthorizedResponseText)
+				.contains(TOKEN_ENDPOINT_URI.toString());
 	}
 
 	@Test

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/util/HttpClientTestFactory.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/util/HttpClientTestFactory.java
@@ -5,15 +5,17 @@
  */
 package com.sap.cloud.security.xsuaa.util;
 
-import static org.mockito.Mockito.when;
-
+import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicStatusLine;
 import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
 
 public class HttpClientTestFactory {
 
@@ -21,6 +23,9 @@ public class HttpClientTestFactory {
 		CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
 		when(response.getStatusLine()).thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, statusCode, null));
 		when(response.getEntity()).thenReturn(new StringEntity(responseAsJson, ContentType.APPLICATION_JSON));
+		Header[] headers = new Header[1];
+		headers[0] = new BasicHeader("testHeader", "testValue");
+		when(response.getAllHeaders()).thenReturn(headers);
 		return response;
 	}
 


### PR DESCRIPTION
Fixes problem, when `app_tid` is not present in token and sending only `x-client_id` header returns 400 from IAS.
`x-client_id` and `x-app_tid` headers have to be used together or not at all.