### PR TITLE
Add x-app_tid and x-client_id headers only when both are available

### DIFF
--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenService.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenService.java
@@ -11,6 +11,7 @@ import com.sap.cloud.security.xsuaa.Assertions;
 import com.sap.cloud.security.xsuaa.http.HttpHeaders;
 import com.sap.cloud.security.xsuaa.tokenflows.TokenCacheConfiguration;
 import com.sap.cloud.security.xsuaa.util.HttpClientUtil;
+import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -109,7 +110,9 @@ public class DefaultOAuth2TokenService extends AbstractOAuth2TokenService {
 				throw OAuth2ServiceException.builder("Error retrieving JWT token")
 						.withStatusCode(statusCode)
 						.withUri(httpPost.getURI())
-						.withHeaders(Arrays.toString(response.getAllHeaders()))
+						.withHeaders(response.getAllHeaders() != null ? Arrays.stream(response.getAllHeaders()).map(
+										Header::toString)
+								.toArray(String[]::new) : null)
 						.withResponseBody(responseBodyAsString)
 						.build();
 			}

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2ServiceException.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2ServiceException.java
@@ -149,7 +149,7 @@ public class OAuth2ServiceException extends IOException {
 		}
 
 		private String createHeaderMessage() {
-			return headersString == null ? null : "Headers " + headersString;
+			return headersString == null ? null : "Response Headers " + headersString;
 		}
 
 	}

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/SpringOAuth2TokenKeyService.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/SpringOAuth2TokenKeyService.java
@@ -17,6 +17,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
 import static com.sap.cloud.security.xsuaa.http.HttpHeaders.X_APP_TID;
 import static com.sap.cloud.security.xsuaa.http.HttpHeaders.X_CLIENT_ID;
@@ -43,41 +44,51 @@ public class SpringOAuth2TokenKeyService implements OAuth2TokenKeyService {
 	public String retrieveTokenKeys(@Nonnull URI tokenKeysEndpointUri, @Nullable String tenantId, @Nullable String clientId)
 			throws OAuth2ServiceException {
 		Assertions.assertNotNull(tokenKeysEndpointUri, "Token key endpoint must not be null!");
+		HttpHeaders headers = new HttpHeaders();
+		headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+		headers.set(HttpHeaders.USER_AGENT, HttpClientUtil.getUserAgent());
+		if (tenantId != null && clientId != null) {
+			headers.set(X_APP_TID, tenantId);
+			headers.set(X_CLIENT_ID, clientId);
+		}
 		try {
-			// create headers
-			HttpHeaders headers = new HttpHeaders();
-			headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
-			headers.set(HttpHeaders.USER_AGENT, HttpClientUtil.getUserAgent());
-			if (tenantId != null) {
-				headers.set(X_APP_TID, tenantId);
-			}
-			if (clientId != null) {
-				headers.set(X_CLIENT_ID, clientId);
-			}
 			ResponseEntity<String> response = restOperations.exchange(
-					tokenKeysEndpointUri, GET, new HttpEntity(headers), String.class);
+					tokenKeysEndpointUri, GET, new HttpEntity<>(headers), String.class);
 			if (HttpStatus.OK.value() == response.getStatusCode().value()) {
 				LOGGER.debug("Successfully retrieved token keys from {} for tenant '{}'", tokenKeysEndpointUri, tenantId);
 				return response.getBody();
 			} else {
-				throw OAuth2ServiceException.builder("Error retrieving token keys")
+				throw OAuth2ServiceException.builder(
+								"Error retrieving token keys. Request headers [" + headers.entrySet().stream()
+										.map(h -> h.getKey() + ": " + String.join(",", h.getValue()))
+										.collect(Collectors.joining(", ")) + "]")
 						.withUri(tokenKeysEndpointUri)
-						.withHeaders(X_APP_TID + "=" + tenantId)
+						.withHeaders(response.getHeaders().size() != 0 ? response.getHeaders().entrySet().stream().map(
+										h -> h.getKey() + ": " + String.join(",", h.getValue()))
+								.toArray(String[]::new) : null)
 						.withStatusCode(response.getStatusCodeValue())
 						.withResponseBody(response.getBody())
 						.build();
 			}
 		} catch (HttpStatusCodeException ex) {
-			throw OAuth2ServiceException.builder("Error retrieving token keys")
+			throw OAuth2ServiceException.builder(
+							"Error retrieving token keys. Request headers [" + headers.entrySet().stream()
+							.map(h -> h.getKey() + ": " + String.join(",", h.getValue())))
 					.withUri(tokenKeysEndpointUri)
-					.withHeaders(X_APP_TID + "=" + tenantId)
+					.withHeaders(ex.getResponseHeaders() != null ? ex.getResponseHeaders().entrySet().stream().map(
+									h -> h.getKey() + ": " + String.join(",", h.getValue()))
+							.toArray(String[]::new) : null)
 					.withStatusCode(ex.getStatusCode().value())
 					.withResponseBody(ex.getResponseBodyAsString())
 					.build();
 		} catch (Exception e) {
-			throw OAuth2ServiceException.builder("Unexpected error retrieving token keys: " + e.getMessage())
-					.withUri(tokenKeysEndpointUri)
-					.build();
+			if (e instanceof OAuth2ServiceException ) {
+				throw (OAuth2ServiceException) e;
+			} else {
+				throw OAuth2ServiceException.builder("Unexpected error retrieving token keys: " + e.getMessage())
+						.withUri(tokenKeysEndpointUri)
+						.build();
+			}
 		}
 	}
 

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenKeyServiceTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenKeyServiceTest.java
@@ -9,7 +9,6 @@ import com.sap.cloud.security.xsuaa.http.HttpHeaders;
 import com.sap.cloud.security.xsuaa.util.HttpClientTestFactory;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -67,7 +66,7 @@ public class DefaultOAuth2TokenKeyServiceTest {
 		assertThatThrownBy(() -> cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, APP_TID, CLIENT_ID))
 				.isInstanceOf(OAuth2ServiceException.class)
 				.hasMessageContaining(errorDescription)
-				.hasMessageContaining("Request headers [x-app_tid: 92768714-4c2e-4b79-bc1b-009a4127ee3c, x-client_id: client-id, User-Agent: token-client/3.1.2]")
+				.hasMessageContaining("Request headers [x-app_tid: 92768714-4c2e-4b79-bc1b-009a4127ee3c, x-client_id: client-id, User-Agent: token-client/")
 				.hasMessageContaining("'Something went wrong'")
 				.hasMessageContaining("Error retrieving token keys")
 				.hasMessageContaining("Response Headers [testHeader: testValue]")
@@ -79,10 +78,7 @@ public class DefaultOAuth2TokenKeyServiceTest {
 		String errorDescription = "Something went wrong";
 		CloseableHttpResponse response = HttpClientTestFactory
 				.createHttpResponse(errorDescription, HttpStatus.SC_BAD_REQUEST);
-		when(httpClient.execute(any(), any(ResponseHandler.class))).thenAnswer(invocation -> {
-			ResponseHandler responseHandler = invocation.getArgument(1);
-			return responseHandler.handleResponse(response);
-		});
+		when(httpClient.execute(any())).thenReturn(response);
 
 		OAuth2ServiceException e = assertThrows(OAuth2ServiceException.class,
 				() -> cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, null, CLIENT_ID));
@@ -91,7 +87,7 @@ public class DefaultOAuth2TokenKeyServiceTest {
 		assertThat(e.getHttpStatusCode()).isEqualTo(400);
 		assertThat(e.getMessage())
 				.contains(errorDescription)
-				.contains("Request headers [User-Agent: token-client/3.1.2].")
+				.contains("Request headers [User-Agent: token-client/")
 				.contains("Response Headers [testHeader: testValue]")
 				.contains("Http status code 400")
 				.contains("Server URI https://tokenKeys.io/token_keys");

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenServiceTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenServiceTest.java
@@ -40,6 +40,7 @@ import static com.sap.cloud.security.servlet.MDCHelper.CORRELATION_ID;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -130,11 +131,14 @@ public class DefaultOAuth2TokenServiceTest {
 				.createHttpResponse(unauthorizedResponseText, HttpStatus.SC_UNAUTHORIZED);
 		when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(response);
 
-		assertThatThrownBy(() -> requestAccessToken(emptyMap()))
-				.isInstanceOf(OAuth2ServiceException.class)
-				.hasMessageContaining(unauthorizedResponseText)
-				.hasMessageContaining(TOKEN_ENDPOINT_URI.toString())
-				.extracting("httpStatusCode").isEqualTo(HttpStatus.SC_UNAUTHORIZED);
+		OAuth2ServiceException e = assertThrows(OAuth2ServiceException.class,
+				() -> requestAccessToken(emptyMap()));
+
+		assertThat(e.getHeaders().get(0)).isEqualTo("testHeader: testValue");
+		assertThat(e.getHttpStatusCode()).isEqualTo(HttpStatus.SC_UNAUTHORIZED);
+		assertThat(e.getMessage())
+				.contains(unauthorizedResponseText)
+				.contains(TOKEN_ENDPOINT_URI.toString());
 	}
 
 	@Test

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/SpringOAuth2TokenKeyServiceTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/SpringOAuth2TokenKeyServiceTest.java
@@ -85,7 +85,8 @@ public class SpringOAuth2TokenKeyServiceTest {
 		assertThat(e.getMessage())
 				.contains(TOKEN_KEYS_ENDPOINT_URI.toString())
 				.contains(String.valueOf(HttpStatus.BAD_REQUEST.value()))
-				.contains("Request headers [Accept: application/json, User-Agent: token-client/3.1.2, x-app_tid: 92768714-4c2e-4b79-bc1b-009a4127ee3c, x-client_id: client-id]")
+				.contains("Request headers [Accept: application/json, User-Agent: token-client/")
+				.contains("x-app_tid: 92768714-4c2e-4b79-bc1b-009a4127ee3c, x-client_id: client-id]")
 				.contains("Response Headers ")
 				.contains(errorMessage);
 		assertThat(e.getHttpStatusCode()).isEqualTo(400);
@@ -104,7 +105,7 @@ public class SpringOAuth2TokenKeyServiceTest {
 		assertThat(e.getMessage())
 				.contains(TOKEN_KEYS_ENDPOINT_URI.toString())
 				.contains(String.valueOf(HttpStatus.BAD_REQUEST.value()))
-				.contains("Request headers [Accept: application/json, User-Agent: token-client/3.1.2]") //if app_tid is missing the x-app_tid and x-client_id headers shouldn't be sent
+				.contains("Request headers [Accept: application/json, User-Agent: token-client/") //if app_tid is missing the x-app_tid and x-client_id headers shouldn't be sent
 				.contains(errorMessage);
 	}
 

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/util/HttpClientTestFactory.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/util/HttpClientTestFactory.java
@@ -5,11 +5,13 @@
  */
 package com.sap.cloud.security.xsuaa.util;
 
+import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicStatusLine;
 import org.mockito.Mockito;
 
@@ -21,6 +23,9 @@ public class HttpClientTestFactory {
 		CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
 		when(response.getStatusLine()).thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, statusCode, null));
 		when(response.getEntity()).thenReturn(new StringEntity(responseAsJson, ContentType.APPLICATION_JSON));
+		Header[] headers = new Header[1];
+		headers[0] = new BasicHeader("testHeader", "testValue");
+		when(response.getAllHeaders()).thenReturn(headers);
 		return response;
 	}
 


### PR DESCRIPTION
Fixes problem, when app_tid is not present in token and sending only x-client_id header returns 400 from IAS.
x-client_id and x-app_tid headers have to be used together or not at all.