### PR TITLE
docs: add repository map link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Maven Build main](https://github.com/SAP/cloud-security-services-integration-library/actions/workflows/maven-build.yml/badge.svg?branch=main)](https://github.com/SAP/cloud-security-services-integration-library/actions/workflows/maven-build.yml)
 [![Fosstars security rating](https://raw.githubusercontent.com/SAP/cloud-security-xsuaa-integration/fosstars-report/fosstars_badge.svg)](https://github.com/SAP/cloud-security-xsuaa-integration/blob/fosstars-report/fosstars_report.md)
 [![CodeQL](https://github.com/SAP/cloud-security-xsuaa-integration/workflows/CodeQL/badge.svg)](https://github.com/SAP/cloud-security-xsuaa-integration/actions?query=workflow%3ACodeQL)
+[![Project Map](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/sapcloudsecurityservicesintegrationlibrary/)
 
 
 


### PR DESCRIPTION
Adding a link to the high-level diagrams including module, library dependency and others (https://sourcespy.com/github/sapcloudsecurityservicesintegrationlibrary/). Built directly from source and updated on schedule. Intended to simplify developer's introduction to the project. In the spirit of transparency - I am the author of the diagrams. 

Hope contributors find it useful.