### PR TITLE
Bump org.json.version from 20230618 to 20231013

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 - [token-client]
 
 #### Dependency upgrades
+- Bump org.json.version from 20230618 to 20231013
 - Bump spring.security.version from 5.8.6 to 5.8.7
 - Bump spring.boot.version from 2.7.15 to 2.7.16
 - Bump spring.core.version from 5.3.29 to 5.3.30

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 		<reactor.version>3.4.33</reactor.version>
 		<log4j2.version>2.20.0</log4j2.version>
 		<slf4j.api.version>1.7.36</slf4j.api.version> <!--see also here http://www.slf4j.org/faq.html#changesInVersion18 -->
-		<org.json.version>20230618</org.json.version>
+		<org.json.version>20231013</org.json.version>
 		<sap.cloud.env.servicebinding.version>0.10.0</sap.cloud.env.servicebinding.version>
 		<apache.httpclient.version>4.5.14</apache.httpclient.version>
 		<caffeine.version>2.9.3</caffeine.version>


### PR DESCRIPTION
Fixes https://nvd.nist.gov/vuln/detail/CVE-2023-5072