### PR TITLE
Minor Performance Improvement: Avoid Several Redundant Calls to Environment Layer During Bootstrapping

### DIFF
--- a/spring-security/src/main/java/com/sap/cloud/security/spring/config/IdentityServicesPropertySourceFactory.java
+++ b/spring-security/src/main/java/com/sap/cloud/security/spring/config/IdentityServicesPropertySourceFactory.java
@@ -102,13 +102,14 @@ public class IdentityServicesPropertySourceFactory implements PropertySourceFact
 	@Nonnull
 	private Properties getIasProperties(Environment environment) {
 		Properties properties = new Properties();
-		if (environment.getIasConfiguration() != null) {
+		final OAuth2ServiceConfiguration iasConfiguration = environment.getIasConfiguration();
+		if (iasConfiguration != null) {
 			for (String key : IAS_ATTRIBUTES) {
-				if (environment.getIasConfiguration().hasProperty(key)) { // will not find "domains" among properties
-					properties.put(IAS_PREFIX + key, environment.getIasConfiguration().getProperty(key));
+				if (iasConfiguration.hasProperty(key)) { // will not find "domains" among properties
+					properties.put(IAS_PREFIX + key, iasConfiguration.getProperty(key));
 				}
 			}
-			properties.put(IAS_PREFIX + DOMAINS, environment.getIasConfiguration().getDomains());
+			properties.put(IAS_PREFIX + DOMAINS, iasConfiguration.getDomains());
 		}
 		return properties;
 	}

--- a/spring-security/src/main/java/com/sap/cloud/security/spring/config/IdentityServicesPropertySourceFactory.java
+++ b/spring-security/src/main/java/com/sap/cloud/security/spring/config/IdentityServicesPropertySourceFactory.java
@@ -7,6 +7,7 @@ package com.sap.cloud.security.spring.config;
 
 import com.sap.cloud.security.config.Environment;
 import com.sap.cloud.security.config.Environments;
+import com.sap.cloud.security.config.OAuth2ServiceConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.PropertiesPropertySource;
@@ -76,19 +77,22 @@ public class IdentityServicesPropertySourceFactory implements PropertySourceFact
 	@Nonnull
 	private Properties getXsuaaProperties(Environment environment, boolean multipleXsuaaServicesBound) {
 		Properties properties = new Properties();
-		if (environment.getXsuaaConfiguration() != null) {
+		final OAuth2ServiceConfiguration xsuaaConfiguration = environment.getXsuaaConfiguration();
+		if (xsuaaConfiguration != null) {
 			String xsuaaPrefix = multipleXsuaaServicesBound ? PROPERTIES_KEY + ".xsuaa[0]." : XSUAA_PREFIX;
 			for (String key : XSUAA_ATTRIBUTES) {
-				if (environment.getXsuaaConfiguration().hasProperty(key)) {
-					properties.put(xsuaaPrefix + key, environment.getXsuaaConfiguration().getProperty(key));
+				if (xsuaaConfiguration.hasProperty(key)) {
+					properties.put(xsuaaPrefix + key, xsuaaConfiguration.getProperty(key));
 				}
 			}
 		}
 		if (multipleXsuaaServicesBound) {
+			final OAuth2ServiceConfiguration xsuaaConfigurationForTokenExchange = 
+					environment.getXsuaaConfigurationForTokenExchange();
 			for (String key : XSUAA_ATTRIBUTES) {
-				if (environment.getXsuaaConfigurationForTokenExchange().hasProperty(key)) {
+				if (xsuaaConfigurationForTokenExchange.hasProperty(key)) {
 					properties.put(PROPERTIES_KEY + ".xsuaa[1]." + key,
-							environment.getXsuaaConfigurationForTokenExchange().getProperty(key));
+							xsuaaConfigurationForTokenExchange.getProperty(key));
 				}
 			}
 		}


### PR DESCRIPTION
During a debugging session, I stumbled over a lot of redundant calls to the `CFEnvironment` class originating from `IdentityServicesPropertySourceFactory`. Although not causing any external calls, still the performance may be degraded slightly due to this. 
It seems rather easy to prevent the unnecessary calls by introducing a local variable. IMO that also makes the code easier to read. The pattern may be applied both when determining XSUAA service instances and IAS service instances. I have adjusted both occurrences.

As this change is expected to be trivial (bugfix contribution only) and should be non-disruptive for any consumer, I don't expect any credit to be mentioned.

## Dependency
- [ ] requires #1314 or #1316 (whichever is chosen) to fix the pipeline/voter; no technical dependency known.