### PR TITLE
Make Selection of XSUAA/IAS Service Instances from Environments reproducible/predictable

### DIFF
--- a/env/src/main/java/com/sap/cloud/security/config/ServiceBindingMapper.java
+++ b/env/src/main/java/com/sap/cloud/security/config/ServiceBindingMapper.java
@@ -14,7 +14,7 @@ import static com.sap.cloud.security.config.Service.IAS;
 import static com.sap.cloud.security.config.cf.CFConstants.IAS.DOMAIN;
 import static com.sap.cloud.security.config.cf.CFConstants.IAS.DOMAINS;
 import static com.sap.cloud.security.config.cf.CFConstants.SERVICE_PLAN;
-import static com.sap.cloud.security.config.cf.CFConstants.NAME;;
+import static com.sap.cloud.security.config.cf.CFConstants.NAME;
 
 @Deprecated
 public class ServiceBindingMapper {

--- a/env/src/main/java/com/sap/cloud/security/config/ServiceBindingMapper.java
+++ b/env/src/main/java/com/sap/cloud/security/config/ServiceBindingMapper.java
@@ -14,7 +14,7 @@ import static com.sap.cloud.security.config.Service.IAS;
 import static com.sap.cloud.security.config.cf.CFConstants.IAS.DOMAIN;
 import static com.sap.cloud.security.config.cf.CFConstants.IAS.DOMAINS;
 import static com.sap.cloud.security.config.cf.CFConstants.SERVICE_PLAN;
-import static com.sap.cloud.security.config.cf.CFConstants.INSTANCE_NAME;;
+import static com.sap.cloud.security.config.cf.CFConstants.NAME;;
 
 @Deprecated
 public class ServiceBindingMapper {
@@ -39,8 +39,11 @@ public class ServiceBindingMapper {
 		TypedMapView credentials = TypedMapView.ofCredentials(b);
 		OAuth2ServiceConfigurationBuilder builder = OAuth2ServiceConfigurationBuilder.forService(service)
 				.withProperties(credentials.getEntries(String.class))
-				.withProperty(INSTANCE_NAME, b.getName().orElse("UNDEFINED")) // TODO: Clarify what is the expected K8S behavior here
 				.withProperty(SERVICE_PLAN, b.getServicePlan().orElse(K8sConstants.Plan.APPLICATION.name()).toUpperCase());
+		
+		if (b.getName().isPresent()) {
+			builder = builder.withProperty(NAME, b.getName().get());
+		}
 		
 		if (IAS.equals(service)) {
 			parseDomains(builder, credentials);

--- a/env/src/main/java/com/sap/cloud/security/config/ServiceBindingMapper.java
+++ b/env/src/main/java/com/sap/cloud/security/config/ServiceBindingMapper.java
@@ -14,6 +14,7 @@ import static com.sap.cloud.security.config.Service.IAS;
 import static com.sap.cloud.security.config.cf.CFConstants.IAS.DOMAIN;
 import static com.sap.cloud.security.config.cf.CFConstants.IAS.DOMAINS;
 import static com.sap.cloud.security.config.cf.CFConstants.SERVICE_PLAN;
+import static com.sap.cloud.security.config.cf.CFConstants.INSTANCE_NAME;;
 
 @Deprecated
 public class ServiceBindingMapper {
@@ -38,8 +39,9 @@ public class ServiceBindingMapper {
 		TypedMapView credentials = TypedMapView.ofCredentials(b);
 		OAuth2ServiceConfigurationBuilder builder = OAuth2ServiceConfigurationBuilder.forService(service)
 				.withProperties(credentials.getEntries(String.class))
+				.withProperty(INSTANCE_NAME, b.getName().orElse("UNDEFINED")) // TODO: Clarify what is the expected K8S behavior here
 				.withProperty(SERVICE_PLAN, b.getServicePlan().orElse(K8sConstants.Plan.APPLICATION.name()).toUpperCase());
-
+		
 		if (IAS.equals(service)) {
 			parseDomains(builder, credentials);
 		}

--- a/env/src/main/java/com/sap/cloud/security/config/cf/CFEnvironment.java
+++ b/env/src/main/java/com/sap/cloud/security/config/cf/CFEnvironment.java
@@ -201,15 +201,25 @@ public class CFEnvironment implements Environment {
 						
 						/*
 						 * Note that we know here that we are in a CF Environment!
-						 * The CF Environment variables always contain an instance_name property.
+						 * The CF Environment variables always contain a "name" property.
 						 * The call ServiceBindingMapper::mapToOAuth2ServiceConfigurationBuilder
 						 * ensured that the property was transfered.
 						 */
 						
-						final String o1InstanceName = o1.getProperty(CFConstants.NAME);
-						final String o2InstanceName = o2.getProperty(CFConstants.NAME);
+						final String o1Name = o1.getProperty(CFConstants.NAME);
+						final String o2Name = o2.getProperty(CFConstants.NAME);
 						
-						return o1InstanceName.compareTo(o2InstanceName);
+						if (o1Name == null && o2Name == null) {
+							return 0;
+						}
+						if (o1Name == null) {
+							return 1;
+						}
+						if (o2Name == null) {
+							return -1;
+						}
+						
+						return o1Name.compareTo(o2Name);
 					}
 				})
 				.findFirst()

--- a/env/src/main/java/com/sap/cloud/security/config/cf/CFEnvironment.java
+++ b/env/src/main/java/com/sap/cloud/security/config/cf/CFEnvironment.java
@@ -65,7 +65,7 @@ public class CFEnvironment implements Environment {
 		instance.environmentVariableReader = vcapProvider;
 		instance.serviceBindingAccessor = new SapVcapServicesServiceBindingAccessor(vcapProvider);
 		
-		String serviceSortedConfigValue = vcapProvider.apply(CFConstants.CONFIG_SERVICE_SORTED);
+		final String serviceSortedConfigValue = vcapProvider.apply(CFConstants.CONFIG_SERVICE_SORTED);
 		if (serviceSortedConfigValue != null && serviceSortedConfigValue.compareToIgnoreCase("true") == 0) {
 			instance.serviceSorted = true;
 		}

--- a/env/src/main/java/com/sap/cloud/security/config/cf/CFEnvironment.java
+++ b/env/src/main/java/com/sap/cloud/security/config/cf/CFEnvironment.java
@@ -31,7 +31,6 @@ import static com.sap.cloud.security.config.cf.CFConstants.VCAP_SERVICES;
  * parsing the {@code VCAP_SERVICES} system environment variable.
  */
 public class CFEnvironment implements Environment {
-
 	private ServiceBindingAccessor serviceBindingAccessor;
 	private UnaryOperator<String> environmentVariableReader = System::getenv;
 	private final Map<Service, List<OAuth2ServiceConfiguration>> serviceConfigurations;
@@ -66,7 +65,7 @@ public class CFEnvironment implements Environment {
 		instance.environmentVariableReader = vcapProvider;
 		instance.serviceBindingAccessor = new SapVcapServicesServiceBindingAccessor(vcapProvider);
 		
-		String serviceSortedConfigValue = vcapProvider.apply("COM_SAP_CLOUD_SECURITY_CONFIG_SERVICE_SORTED");
+		String serviceSortedConfigValue = vcapProvider.apply(CFConstants.CONFIG_SERVICE_SORTED);
 		if (serviceSortedConfigValue != null && serviceSortedConfigValue.compareToIgnoreCase("true") == 0) {
 			instance.serviceSorted = true;
 		}
@@ -234,8 +233,7 @@ public class CFEnvironment implements Environment {
 			});
 		}
 		
-		return stream.findFirst()
-				.orElse(null);
+		return stream.findFirst().orElse(null);
 	}
 
 	/**

--- a/env/src/main/java/com/sap/cloud/security/config/cf/CFEnvironment.java
+++ b/env/src/main/java/com/sap/cloud/security/config/cf/CFEnvironment.java
@@ -199,8 +199,15 @@ public class CFEnvironment implements Environment {
 							return -1;
 						}
 						
-						final String o1InstanceName = o1.getProperty(CFConstants.INSTANCE_NAME);
-						final String o2InstanceName = o2.getProperty(CFConstants.INSTANCE_NAME);
+						/*
+						 * Note that we know here that we are in a CF Environment!
+						 * The CF Environment variables always contain an instance_name property.
+						 * The call ServiceBindingMapper::mapToOAuth2ServiceConfigurationBuilder
+						 * ensured that the property was transfered.
+						 */
+						
+						final String o1InstanceName = o1.getProperty(CFConstants.NAME);
+						final String o2InstanceName = o2.getProperty(CFConstants.NAME);
 						
 						return o1InstanceName.compareTo(o2InstanceName);
 					}

--- a/env/src/main/java/com/sap/cloud/security/config/cf/CFEnvironment.java
+++ b/env/src/main/java/com/sap/cloud/security/config/cf/CFEnvironment.java
@@ -185,6 +185,26 @@ public class CFEnvironment implements Environment {
 	public OAuth2ServiceConfiguration loadForServicePlan(Service service, Plan plan) {
 		return loadAllForService(service).stream()
 				.filter(configuration -> Plan.from(configuration.getProperty(CFConstants.SERVICE_PLAN)).equals(plan))
+				.sorted(new Comparator<OAuth2ServiceConfiguration>() {
+
+					@Override
+					public int compare(OAuth2ServiceConfiguration o1, OAuth2ServiceConfiguration o2) {
+						if (o1 == null && o2 == null) {
+							return 0;
+						}
+						if (o1 == null) {
+							return 1;
+						}
+						if (o2 == null) {
+							return -1;
+						}
+						
+						final String o1InstanceName = o1.getProperty(CFConstants.INSTANCE_NAME);
+						final String o2InstanceName = o2.getProperty(CFConstants.INSTANCE_NAME);
+						
+						return o1InstanceName.compareTo(o2InstanceName);
+					}
+				})
 				.findFirst()
 				.orElse(null);
 	}

--- a/env/src/test/java/com/sap/cloud/security/config/ServiceBindingMapperInstanceNameTest.java
+++ b/env/src/test/java/com/sap/cloud/security/config/ServiceBindingMapperInstanceNameTest.java
@@ -1,0 +1,58 @@
+package com.sap.cloud.security.config;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.sap.cloud.environment.servicebinding.SapVcapServicesServiceBindingAccessor;
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+import com.sap.cloud.environment.servicebinding.api.ServiceBindingAccessor;
+import com.sap.cloud.security.config.cf.CFConstants;
+
+class ServiceBindingMapperInstanceNameTest {
+
+	private static ServiceBinding xsuaaBinding;
+	private static ServiceBinding xsuaaBindingNoInstanceName;
+	private static ServiceBinding iasBinding;
+
+	@BeforeAll
+	static void setupClass() throws IOException {
+		xsuaaBinding = readServiceBindingFromJson(Service.XSUAA, "/vcapXsuaaServiceSingleBinding.json");
+		xsuaaBindingNoInstanceName = readServiceBindingFromJson(Service.XSUAA, "/vcapXsuaaServiceSingleBindingNoName.json");
+		iasBinding = readServiceBindingFromJson(Service.IAS, "/vcapIasServiceSingleBinding.json");
+	}
+
+	private static ServiceBinding readServiceBindingFromJson(Service service, String jsonPath) throws IOException {
+		String vcapJson = IOUtils.resourceToString(jsonPath, UTF_8);
+		ServiceBindingAccessor sba = new SapVcapServicesServiceBindingAccessor(any -> vcapJson);
+
+		return sba.getServiceBindings().stream().filter(b -> service.equals(Service.from(b.getServiceName().orElse("")))).findFirst().get();
+	}
+
+	@Test
+	void getXsuaaConfiguration() {
+		OAuth2ServiceConfiguration config = ServiceBindingMapper.mapToOAuth2ServiceConfigurationBuilder(xsuaaBinding).build();
+		assertThat(config.getProperty(CFConstants.NAME)).isEqualTo("example-xsuaa");
+	}
+
+	@Test
+	void getIasConfiguration() {
+		OAuth2ServiceConfiguration config = ServiceBindingMapper.mapToOAuth2ServiceConfigurationBuilder(iasBinding).build();
+		assertThat(config.getProperty(CFConstants.NAME)).isEqualTo("myservice");
+	}
+	
+	@Test
+	void getXsuaaConfigurationNoInstanceName() {
+		/*
+		 * Ensure that there is no error raised even if no instance name was available (e.g. K8S environment)
+		 */
+		OAuth2ServiceConfiguration config = ServiceBindingMapper.mapToOAuth2ServiceConfigurationBuilder(xsuaaBindingNoInstanceName).build();
+		assertThat(config.getProperty(CFConstants.NAME)).isNull();
+	}
+}

--- a/env/src/test/java/com/sap/cloud/security/config/cf/CFEnvironmentTest.java
+++ b/env/src/test/java/com/sap/cloud/security/config/cf/CFEnvironmentTest.java
@@ -36,6 +36,7 @@ public class CFEnvironmentTest {
 	private final String vcapXsuaa;
 	private final String vcapMultipleXsuaa;
 	private final String vcapFourXsuaa;
+	private final String vcapFourXsuaaReverseOrder;
 	private final String vcapIas;
 	private final String vcapXsa;
 	private CFEnvironment cut;
@@ -46,6 +47,7 @@ public class CFEnvironmentTest {
 		vcapIas = IOUtils.resourceToString("/vcapIasServiceSingleBinding.json", UTF_8);
 		vcapXsa = IOUtils.resourceToString("/vcapXsuaaXsaSingleBinding.json", UTF_8);
 		vcapFourXsuaa = IOUtils.resourceToString("/vcapXsuaaServiceFourBindings.json", UTF_8);
+		vcapFourXsuaaReverseOrder = IOUtils.resourceToString("/vcapXsuaaServiceFourBindingsReverseOrder.json", UTF_8);
 	}
 
 	@Before
@@ -245,6 +247,25 @@ public class CFEnvironmentTest {
 	@Test
 	public void getConfigurationOfFourInstance() {
 		cut = CFEnvironment.getInstance((str) -> vcapFourXsuaa);
+
+		assertThat(cut.getNumberOfXsuaaConfigurations()).isEqualTo(4);
+		OAuth2ServiceConfiguration appServConfig = cut.getXsuaaConfiguration();
+		OAuth2ServiceConfiguration brokerServConfig = cut.getXsuaaConfigurationForTokenExchange();
+
+		assertThat(appServConfig.getService()).isEqualTo(Service.XSUAA);
+		assertThat(Plan.from(appServConfig.getProperty(SERVICE_PLAN))).isEqualTo(Plan.APPLICATION);
+		assertThat(appServConfig.getProperty(INSTANCE_NAME)).isEqualTo("xsuaa-app");
+
+		assertThat(brokerServConfig).isNotEqualTo(appServConfig);
+		assertThat(brokerServConfig.getService()).isEqualTo(Service.XSUAA);
+		assertThat(Plan.from(brokerServConfig.getProperty(SERVICE_PLAN))).isEqualTo(Plan.BROKER);
+		assertThat(brokerServConfig).isSameAs(cut.getXsuaaConfigurationForTokenExchange());
+		assertThat(brokerServConfig.getProperty(INSTANCE_NAME)).isEqualTo("xsuaa-broker");
+	}
+	
+	@Test
+	public void getConfigurationOfFourInstanceReverseOrder() {
+		cut = CFEnvironment.getInstance((str) -> vcapFourXsuaaReverseOrder);
 
 		assertThat(cut.getNumberOfXsuaaConfigurations()).isEqualTo(4);
 		OAuth2ServiceConfiguration appServConfig = cut.getXsuaaConfiguration();

--- a/env/src/test/java/com/sap/cloud/security/config/cf/CFEnvironmentTest.java
+++ b/env/src/test/java/com/sap/cloud/security/config/cf/CFEnvironmentTest.java
@@ -8,7 +8,7 @@ package com.sap.cloud.security.config.cf;
 import static com.sap.cloud.security.config.cf.CFConstants.CLIENT_SECRET;
 import static com.sap.cloud.security.config.cf.CFConstants.CREDENTIALS;
 import static com.sap.cloud.security.config.cf.CFConstants.SERVICE_PLAN;
-import static com.sap.cloud.security.config.cf.CFConstants.INSTANCE_NAME;
+import static com.sap.cloud.security.config.cf.CFConstants.NAME;
 import static com.sap.cloud.security.config.cf.CFConstants.VCAP_APPLICATION;
 import static com.sap.cloud.security.config.cf.CFConstants.VCAP_SERVICES;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -254,13 +254,13 @@ public class CFEnvironmentTest {
 
 		assertThat(appServConfig.getService()).isEqualTo(Service.XSUAA);
 		assertThat(Plan.from(appServConfig.getProperty(SERVICE_PLAN))).isEqualTo(Plan.APPLICATION);
-		assertThat(appServConfig.getProperty(INSTANCE_NAME)).isEqualTo("xsuaa-app");
+		assertThat(appServConfig.getProperty(NAME)).isEqualTo("xsuaa-app");
 
 		assertThat(brokerServConfig).isNotEqualTo(appServConfig);
 		assertThat(brokerServConfig.getService()).isEqualTo(Service.XSUAA);
 		assertThat(Plan.from(brokerServConfig.getProperty(SERVICE_PLAN))).isEqualTo(Plan.BROKER);
 		assertThat(brokerServConfig).isSameAs(cut.getXsuaaConfigurationForTokenExchange());
-		assertThat(brokerServConfig.getProperty(INSTANCE_NAME)).isEqualTo("xsuaa-broker");
+		assertThat(brokerServConfig.getProperty(NAME)).isEqualTo("xsuaa-broker");
 	}
 	
 	@Test
@@ -273,13 +273,13 @@ public class CFEnvironmentTest {
 
 		assertThat(appServConfig.getService()).isEqualTo(Service.XSUAA);
 		assertThat(Plan.from(appServConfig.getProperty(SERVICE_PLAN))).isEqualTo(Plan.APPLICATION);
-		assertThat(appServConfig.getProperty(INSTANCE_NAME)).isEqualTo("xsuaa-app");
+		assertThat(appServConfig.getProperty(NAME)).isEqualTo("xsuaa-app");
 
 		assertThat(brokerServConfig).isNotEqualTo(appServConfig);
 		assertThat(brokerServConfig.getService()).isEqualTo(Service.XSUAA);
 		assertThat(Plan.from(brokerServConfig.getProperty(SERVICE_PLAN))).isEqualTo(Plan.BROKER);
 		assertThat(brokerServConfig).isSameAs(cut.getXsuaaConfigurationForTokenExchange());
-		assertThat(brokerServConfig.getProperty(INSTANCE_NAME)).isEqualTo("xsuaa-broker");
+		assertThat(brokerServConfig.getProperty(NAME)).isEqualTo("xsuaa-broker");
 	}
 
 }

--- a/env/src/test/java/com/sap/cloud/security/config/cf/CFEnvironmentTest.java
+++ b/env/src/test/java/com/sap/cloud/security/config/cf/CFEnvironmentTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.function.UnaryOperator;
 
 import org.apache.commons.io.IOUtils;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -244,9 +245,23 @@ public class CFEnvironmentTest {
 		assertThat(cut.getXsuaaConfiguration()).isNull();
 	}
 	
+	private String vcapFourXsuaaGetEnv(String key) {
+		if (key.equals(CFConstants.VCAP_SERVICES)) {
+			return vcapFourXsuaa;
+		}
+		if (key.equals(CFConstants.VCAP_APPLICATION)) {
+			return "{}";
+		}
+		if (key.equals(CFConstants.CONFIG_SERVICE_SORTED)) {
+			return "true";
+		}
+		Assertions.fail(String.format("Request to unknown environment variable %s", key));
+		return null; // never reached, but required due to formal reasons
+	}
+	
 	@Test
 	public void getConfigurationOfFourInstance() {
-		cut = CFEnvironment.getInstance((str) -> vcapFourXsuaa);
+		cut = CFEnvironment.getInstance(this::vcapFourXsuaaGetEnv);
 
 		assertThat(cut.getNumberOfXsuaaConfigurations()).isEqualTo(4);
 		OAuth2ServiceConfiguration appServConfig = cut.getXsuaaConfiguration();
@@ -263,9 +278,23 @@ public class CFEnvironmentTest {
 		assertThat(brokerServConfig.getProperty(NAME)).isEqualTo("xsuaa-broker");
 	}
 	
+	private String vcapFourXsuaaGetEnvReverseOrder(String key) {
+		if (key.equals(CFConstants.VCAP_SERVICES)) {
+			return vcapFourXsuaaReverseOrder;
+		}
+		if (key.equals(CFConstants.VCAP_APPLICATION)) {
+			return "{}";
+		}
+		if (key.equals(CFConstants.CONFIG_SERVICE_SORTED)) {
+			return "true";
+		}
+		Assertions.fail(String.format("Request to unknown environment variable %s", key));
+		return null; // never reached, but required due to formal reasons
+	}
+	
 	@Test
 	public void getConfigurationOfFourInstanceReverseOrder() {
-		cut = CFEnvironment.getInstance((str) -> vcapFourXsuaaReverseOrder);
+		cut = CFEnvironment.getInstance(this::vcapFourXsuaaGetEnvReverseOrder);
 
 		assertThat(cut.getNumberOfXsuaaConfigurations()).isEqualTo(4);
 		OAuth2ServiceConfiguration appServConfig = cut.getXsuaaConfiguration();

--- a/env/src/test/resources/vcapXsuaaServiceFourBindings.json
+++ b/env/src/test/resources/vcapXsuaaServiceFourBindings.json
@@ -1,0 +1,118 @@
+{
+  "xsuaa": [
+    {
+      "binding_name": null,
+      "credentials": {
+        "apiurl": "https://api.uaadomain.org",
+        "clientid": "sb-na-d6a3278d-5e07-40e9-92ae-546bbfd9cdde!t8066",
+        "clientsecret": "1idLRlbbb9oextvpmS6bfpQXLk=",
+        "identityzone": "id-test-zone",
+        "identityzoneid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "sburl": "https://internal-xsuaa.uaadomain.org",
+        "tenantid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "tenantmode": "shared",
+        "uaadomain": "uaadomain.org",
+        "url": "https://id-test-zone.uaadomain.org",
+        "verificationkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAABBBQ8AMIIBCgKCAQEAx/jN5v1mp/TVn9nTQoYVIUfCsUDHa3Upr5tDZC7mzlTrN2PnwruzyS7w1Jd+StqwW4/vn87ua2YlZzU8Ob0jR4lbOPCKaHIi0kyNtJXQvQ7LZPG8epQLbx0IIP/WLVVVtB8bL5OWuHma3pUnibbmATtbOh5LksQ2zLMngEjUF52JQyzTpjoQkahp0BNe/drlAqO253keiY63FL6belKjJGmSqdnotSXxB2ym+HQ0ShaNvTFLEvi2+ObkyjGWgFpQaoCcGq0KX0y0mPzOvdFsNT+rBFdkHiK+Jl638Sbim1z9fItFbH9hiVwY37R9rLtH1YKi3PuATMjf/DJ7mUluDQIDAQAB-----END PUBLIC KEY-----",
+        "xsappname": "na-d6a3278d-5e07-40e9-92ae-546bbfd9cdde!t8066"
+      },
+      "instance_name": "xsuaa-app",
+      "label": "xsuaa",
+      "name": "xsuaa-app",
+      "plan": "application",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "xsuaa"
+      ],
+      "volume_mounts": []
+    },
+    {
+      "binding_name": null,
+      "credentials": {
+        "apiurl": "https://api.uaadomain.org",
+        "certificate": "",
+        "key": "",
+        "clientid": "sb-xsuaa-broker!b8066",
+        "clientsecret": "sppEXArNzp3tccATO99CZsRKESY=",
+        "identityzone": "id-test-zone",
+        "identityzoneid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "sburl": "https://internal-xsuaa.uaadomain.org",
+        "tenantid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "tenantmode": "dedicated",
+        "trustedclientidsuffix": "|xsuaa-broker!b8066",
+        "uaadomain": "uaadomain.org",
+        "url": "https://id-test-zone.uaadomain.org",
+        "verificationkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAABBBQ8AMIIBCgKCAQEAx/jN5v1mp/TVn9nTQoYVIUfCsUDHa3Upr5tDZC7mzlTrN2PnwruzyS7w1Jd+StqwW4/vn87ua2YlZzU8Ob0jR4lbOPCKaHIi0kyNtJXQvQ7LZPG8epQLbx0IIP/WLVVVtB8bL5OWuHma3pUnibbmATtbOh5LksQ2zLMngEjUF52JQyzTpjoQkahp0BNe/drlAqO253keiY63FL6belKjJGmSqdnotSXxB2ym+HQ0ShaNvTFLEvi2+ObkyjGWgFpQaoCcGq0KX0y0mPzOvdFsNT+rBFdkHiK+Jl638Sbim1z9fItFbH9hiVwY37R9rLtH1YKi3PuATMjf/DJ7mUluDQIDAQAB-----END PUBLIC KEY-----",
+        "xsappname": "xsuaa-broker!b8066"
+      },
+      "instance_name": "xsuaa-broker",
+      "label": "xsuaa",
+      "name": "xsuaa-broker",
+      "plan": "broker",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "xsuaa"
+      ],
+      "volume_mounts": []
+    },
+    {
+      "binding_name": null,
+      "credentials": {
+        "apiurl": "https://api.uaadomain.org",
+        "clientid": "sb-na-d7a3278d-5e07-40e9-92ae-546bbfd9cddf!t8066",
+        "clientsecret": "xyzLRlbbb9oextvpmS6bfpQXLk=",
+        "identityzone": "id-test-zone",
+        "identityzoneid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "sburl": "https://internal-xsuaa.uaadomain.org",
+        "tenantid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "tenantmode": "shared",
+        "uaadomain": "uaadomain.org",
+        "url": "https://id-test-zone.uaadomain.org",
+        "verificationkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAABBBQ8AMIIBCgKCAQEAx/jN5v1mp/TVn9nTQoYVIUfCsUDHa3Upr5tDZC7mzlTrN2PnwruzyS7w1Jd+StqwW4/vn87ua2YlZzU8Ob0jR4lbOPCKaHIi0kyNtJXQvQ7LZPG8epQLbx0IIP/WLVVVtB8bL5OWuHma3pUnibbmATtbOh5LksQ2zLMngEjUF52JQyzTpjoQkahp0BNe/drlAqO253keiY63FL6belKjJGmSqdnotSXxB2ym+HQ0ShaNvTFLEvi2+ObkyjGWgFpQaoCcGq0KX0y0mPzOvdFsNT+rBFdkHiK+Jl638Sbim1z9fItFbH9hiVwY37R9rLtH1YKi3PuATMjf/DJ7mUluDQIDAQAB-----END PUBLIC KEY-----",
+        "xsappname": "na-d7a3278d-5e07-40e9-92ae-546bbfd9cddf!t8066"
+      },
+      "instance_name": "xsuaa-app2",
+      "label": "xsuaa",
+      "name": "xsuaa-app2",
+      "plan": "application",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "xsuaa"
+      ],
+      "volume_mounts": []
+    },
+    {
+      "binding_name": null,
+      "credentials": {
+        "apiurl": "https://api.uaadomain.org",
+        "certificate": "",
+        "key": "",
+        "clientid": "sb-xsuaa-broker2!b8066",
+        "clientsecret": "xyzEXArNzp3tccATO99CZsRKESY=",
+        "identityzone": "id-test-zone",
+        "identityzoneid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "sburl": "https://internal-xsuaa.uaadomain.org",
+        "tenantid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "tenantmode": "dedicated",
+        "trustedclientidsuffix": "|xsuaa-broker!b8066",
+        "uaadomain": "uaadomain.org",
+        "url": "https://id-test-zone.uaadomain.org",
+        "verificationkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAABBBQ8AMIIBCgKCAQEAx/jN5v1mp/TVn9nTQoYVIUfCsUDHa3Upr5tDZC7mzlTrN2PnwruzyS7w1Jd+StqwW4/vn87ua2YlZzU8Ob0jR4lbOPCKaHIi0kyNtJXQvQ7LZPG8epQLbx0IIP/WLVVVtB8bL5OWuHma3pUnibbmATtbOh5LksQ2zLMngEjUF52JQyzTpjoQkahp0BNe/drlAqO253keiY63FL6belKjJGmSqdnotSXxB2ym+HQ0ShaNvTFLEvi2+ObkyjGWgFpQaoCcGq0KX0y0mPzOvdFsNT+rBFdkHiK+Jl638Sbim1z9fItFbH9hiVwY37R9rLtH1YKi3PuATMjf/DJ7mUluDQIDAQAB-----END PUBLIC KEY-----",
+        "xsappname": "xsuaa-broker2!b8066"
+      },
+      "instance_name": "xsuaa-broker2",
+      "label": "xsuaa",
+      "name": "xsuaa-broker2",
+      "plan": "broker",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "xsuaa"
+      ],
+      "volume_mounts": []
+    }
+  ]
+}

--- a/env/src/test/resources/vcapXsuaaServiceFourBindingsReverseOrder.json
+++ b/env/src/test/resources/vcapXsuaaServiceFourBindingsReverseOrder.json
@@ -1,0 +1,118 @@
+{
+  "xsuaa": [
+    {
+      "binding_name": null,
+      "credentials": {
+        "apiurl": "https://api.uaadomain.org",
+        "clientid": "sb-na-d7a3278d-5e07-40e9-92ae-546bbfd9cddf!t8066",
+        "clientsecret": "xyzLRlbbb9oextvpmS6bfpQXLk=",
+        "identityzone": "id-test-zone",
+        "identityzoneid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "sburl": "https://internal-xsuaa.uaadomain.org",
+        "tenantid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "tenantmode": "shared",
+        "uaadomain": "uaadomain.org",
+        "url": "https://id-test-zone.uaadomain.org",
+        "verificationkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAABBBQ8AMIIBCgKCAQEAx/jN5v1mp/TVn9nTQoYVIUfCsUDHa3Upr5tDZC7mzlTrN2PnwruzyS7w1Jd+StqwW4/vn87ua2YlZzU8Ob0jR4lbOPCKaHIi0kyNtJXQvQ7LZPG8epQLbx0IIP/WLVVVtB8bL5OWuHma3pUnibbmATtbOh5LksQ2zLMngEjUF52JQyzTpjoQkahp0BNe/drlAqO253keiY63FL6belKjJGmSqdnotSXxB2ym+HQ0ShaNvTFLEvi2+ObkyjGWgFpQaoCcGq0KX0y0mPzOvdFsNT+rBFdkHiK+Jl638Sbim1z9fItFbH9hiVwY37R9rLtH1YKi3PuATMjf/DJ7mUluDQIDAQAB-----END PUBLIC KEY-----",
+        "xsappname": "na-d7a3278d-5e07-40e9-92ae-546bbfd9cddf!t8066"
+      },
+      "instance_name": "xsuaa-app2",
+      "label": "xsuaa",
+      "name": "xsuaa-app2",
+      "plan": "application",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "xsuaa"
+      ],
+      "volume_mounts": []
+    },
+    {
+      "binding_name": null,
+      "credentials": {
+        "apiurl": "https://api.uaadomain.org",
+        "certificate": "",
+        "key": "",
+        "clientid": "sb-xsuaa-broker2!b8066",
+        "clientsecret": "xyzEXArNzp3tccATO99CZsRKESY=",
+        "identityzone": "id-test-zone",
+        "identityzoneid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "sburl": "https://internal-xsuaa.uaadomain.org",
+        "tenantid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "tenantmode": "dedicated",
+        "trustedclientidsuffix": "|xsuaa-broker!b8066",
+        "uaadomain": "uaadomain.org",
+        "url": "https://id-test-zone.uaadomain.org",
+        "verificationkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAABBBQ8AMIIBCgKCAQEAx/jN5v1mp/TVn9nTQoYVIUfCsUDHa3Upr5tDZC7mzlTrN2PnwruzyS7w1Jd+StqwW4/vn87ua2YlZzU8Ob0jR4lbOPCKaHIi0kyNtJXQvQ7LZPG8epQLbx0IIP/WLVVVtB8bL5OWuHma3pUnibbmATtbOh5LksQ2zLMngEjUF52JQyzTpjoQkahp0BNe/drlAqO253keiY63FL6belKjJGmSqdnotSXxB2ym+HQ0ShaNvTFLEvi2+ObkyjGWgFpQaoCcGq0KX0y0mPzOvdFsNT+rBFdkHiK+Jl638Sbim1z9fItFbH9hiVwY37R9rLtH1YKi3PuATMjf/DJ7mUluDQIDAQAB-----END PUBLIC KEY-----",
+        "xsappname": "xsuaa-broker2!b8066"
+      },
+      "instance_name": "xsuaa-broker2",
+      "label": "xsuaa",
+      "name": "xsuaa-broker2",
+      "plan": "broker",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "xsuaa"
+      ],
+      "volume_mounts": []
+    },
+    {
+      "binding_name": null,
+      "credentials": {
+        "apiurl": "https://api.uaadomain.org",
+        "clientid": "sb-na-d6a3278d-5e07-40e9-92ae-546bbfd9cdde!t8066",
+        "clientsecret": "1idLRlbbb9oextvpmS6bfpQXLk=",
+        "identityzone": "id-test-zone",
+        "identityzoneid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "sburl": "https://internal-xsuaa.uaadomain.org",
+        "tenantid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "tenantmode": "shared",
+        "uaadomain": "uaadomain.org",
+        "url": "https://id-test-zone.uaadomain.org",
+        "verificationkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAABBBQ8AMIIBCgKCAQEAx/jN5v1mp/TVn9nTQoYVIUfCsUDHa3Upr5tDZC7mzlTrN2PnwruzyS7w1Jd+StqwW4/vn87ua2YlZzU8Ob0jR4lbOPCKaHIi0kyNtJXQvQ7LZPG8epQLbx0IIP/WLVVVtB8bL5OWuHma3pUnibbmATtbOh5LksQ2zLMngEjUF52JQyzTpjoQkahp0BNe/drlAqO253keiY63FL6belKjJGmSqdnotSXxB2ym+HQ0ShaNvTFLEvi2+ObkyjGWgFpQaoCcGq0KX0y0mPzOvdFsNT+rBFdkHiK+Jl638Sbim1z9fItFbH9hiVwY37R9rLtH1YKi3PuATMjf/DJ7mUluDQIDAQAB-----END PUBLIC KEY-----",
+        "xsappname": "na-d6a3278d-5e07-40e9-92ae-546bbfd9cdde!t8066"
+      },
+      "instance_name": "xsuaa-app",
+      "label": "xsuaa",
+      "name": "xsuaa-app",
+      "plan": "application",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "xsuaa"
+      ],
+      "volume_mounts": []
+    },
+    {
+      "binding_name": null,
+      "credentials": {
+        "apiurl": "https://api.uaadomain.org",
+        "certificate": "",
+        "key": "",
+        "clientid": "sb-xsuaa-broker!b8066",
+        "clientsecret": "sppEXArNzp3tccATO99CZsRKESY=",
+        "identityzone": "id-test-zone",
+        "identityzoneid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "sburl": "https://internal-xsuaa.uaadomain.org",
+        "tenantid": "a179bf0f-5a57-2276-a3f0-94c6d79bd05b",
+        "tenantmode": "dedicated",
+        "trustedclientidsuffix": "|xsuaa-broker!b8066",
+        "uaadomain": "uaadomain.org",
+        "url": "https://id-test-zone.uaadomain.org",
+        "verificationkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAABBBQ8AMIIBCgKCAQEAx/jN5v1mp/TVn9nTQoYVIUfCsUDHa3Upr5tDZC7mzlTrN2PnwruzyS7w1Jd+StqwW4/vn87ua2YlZzU8Ob0jR4lbOPCKaHIi0kyNtJXQvQ7LZPG8epQLbx0IIP/WLVVVtB8bL5OWuHma3pUnibbmATtbOh5LksQ2zLMngEjUF52JQyzTpjoQkahp0BNe/drlAqO253keiY63FL6belKjJGmSqdnotSXxB2ym+HQ0ShaNvTFLEvi2+ObkyjGWgFpQaoCcGq0KX0y0mPzOvdFsNT+rBFdkHiK+Jl638Sbim1z9fItFbH9hiVwY37R9rLtH1YKi3PuATMjf/DJ7mUluDQIDAQAB-----END PUBLIC KEY-----",
+        "xsappname": "xsuaa-broker!b8066"
+      },
+      "instance_name": "xsuaa-broker",
+      "label": "xsuaa",
+      "name": "xsuaa-broker",
+      "plan": "broker",
+      "provider": null,
+      "syslog_drain_url": null,
+      "tags": [
+        "xsuaa"
+      ],
+      "volume_mounts": []
+    }
+  ]
+}

--- a/env/src/test/resources/vcapXsuaaServiceSingleBindingNoName.json
+++ b/env/src/test/resources/vcapXsuaaServiceSingleBindingNoName.json
@@ -1,0 +1,28 @@
+{
+  "xsuaa": [
+    {
+      "label": "xsuaa",
+      "binding_name": null,
+      "plan": "broker",
+      "provider": null,
+      "instance_name": "my-xsuaa",
+      "syslog_drain_url": null,
+      "tags": [
+        "xsuaa"
+      ],
+      "volume_mounts": [],
+      "credentials": {
+        "clientid": "clientId",
+        "clientsecret": "secret",
+        "identityzone": "uaa",
+        "identityzoneid": "uaa",
+        "sburl": "http://localhost/uaa",
+        "tenantmode": "dedicated",
+        "uaadomain": "auth.com",
+        "url": "https://paastenant.auth.com",
+        "verificationkey": "-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm1QaZzMjtEfHdimrHP3/2Yr+1z685eiOUlwybRVG9i8wsgOUh+PUGuQL8hgulLZWXU5MbwBLTECAEMQbcRTNVTolkq4i67EP6JesHJIFADbK1Ni0KuMcPuiyOLvDKiDEMnYG1XP3X3WCNfsCVT9YoU+lWIrZr/ZsIvQri8jczr4RkynbTBsPaAOygPUlipqDrpadMO1momNCbea/o6GPn38LxEw609ItfgDGhL6f/yVid5pFzZQWb+9l6mCuJww0hnhO6gt6Rv98OWDty9G0frWAPyEfuIW9B+mR/2vGhyU9IbbWpvFXiy9RVbbsM538TCjd5JF2dJvxy24addC4oQIDAQAB-----END PUBLIC KEY-----",
+        "xsappname": "java-hello-world"
+      }
+    }
+  ]
+}

--- a/etc/suppression.xml
+++ b/etc/suppression.xml
@@ -4,6 +4,15 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes><![CDATA[
+        suppresses CVE-2023-5072 as it has been fixed by the latest release 20231013 https://nvd.nist.gov/vuln/detail/CVE-2023-5072
+        file name: json-20231013.jar
+        ]]>
+        </notes>
+        <packageUrl regex="true">^pkg:maven/org\.json/json@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-5072</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
         suppresses CVE-2022-45688 as the affected method is not called by code of this project.
         added a test to https://github.com/SAP/cloud-security-xsuaa-integration/blob/main/env/src/test/java/com/sap/cloud/security/json/DefaultJsonObjectTest.java#L225 to check for vulnerability.
         file name: json-20220924.jar

--- a/java-api/src/main/java/com/sap/cloud/security/config/cf/CFConstants.java
+++ b/java-api/src/main/java/com/sap/cloud/security/config/cf/CFConstants.java
@@ -12,6 +12,8 @@ package com.sap.cloud.security.config.cf;
 public class CFConstants {
 	public static final String VCAP_SERVICES = "VCAP_SERVICES";
 	public static final String VCAP_APPLICATION = "VCAP_APPLICATION";
+	public static final String CONFIG_SERVICE_SORTED = "COM_SAP_CLOUD_SECURITY_CONFIG_SERVICE_SORTED";
+	
 	public static final String CREDENTIALS = "credentials";
 	public static final String SERVICE_PLAN = "plan";
 	public static final String URL = "url";

--- a/java-api/src/main/java/com/sap/cloud/security/config/cf/CFConstants.java
+++ b/java-api/src/main/java/com/sap/cloud/security/config/cf/CFConstants.java
@@ -19,6 +19,7 @@ public class CFConstants {
 	public static final String CLIENT_SECRET = "clientsecret";
 	public static final String CERTIFICATE = "certificate";
 	public static final String KEY = "key";
+	public static final String INSTANCE_NAME = "instance_name";
 
 	private CFConstants() {
 	}

--- a/java-api/src/main/java/com/sap/cloud/security/config/cf/CFConstants.java
+++ b/java-api/src/main/java/com/sap/cloud/security/config/cf/CFConstants.java
@@ -19,7 +19,16 @@ public class CFConstants {
 	public static final String CLIENT_SECRET = "clientsecret";
 	public static final String CERTIFICATE = "certificate";
 	public static final String KEY = "key";
-	public static final String INSTANCE_NAME = "instance_name";
+	
+	/*
+	 * Mind the difference between
+	 * - binding_name
+	 * - instance_name
+	 * and 
+	 * - name (which defaults to binding_name, if exists, or instance_name as fallback).
+	 * For further details refer to section "VCAP_SERVICES" at https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html
+	 */
+	public static final String NAME = "name";
 
 	private CFConstants() {
 	}

--- a/spring-security/README.md
+++ b/spring-security/README.md
@@ -192,6 +192,15 @@ IdentityServiceConfiguration identityServiceConfiguration;
 
 Alternatively, you can also access the information with `Environments.getCurrent()`, which is provided with `java-security`.
 
+#### [Optional] Having More Than One XSUAA Service Instance per Plan in Cloud Foundry
+
+In case that you have more than one XSUAA service instances per plan (e. g. two service instances of plan `application` or two service instances of plan `broker`), then by default the library will pick an arbitrary one of them.
+
+To prevent this in a Cloud Foundry environment and to ensure that the library will pick the service instance, whose `name` attribute in the `VCAP_SERVICES` is lexicographically the lower one, set the variable `COM_SAP_CLOUD_SECURITY_CONFIG_SERVICE_SORTED` to `true` (four letters, case insensitive). Note that this variable must be set in the same environment (typically the application program environment, in rare cases also Java system properties) where the `VCAP_SERVICES` is provided. Setting it in another environment will cause that setting is ignored silently.
+
+The configuration option has been introduced due to avoid possible compatibility issues.
+
+
 ### [Optional] Audit Logging
 In case you have implemented a central Exception Handler as described with [Baeldung Tutorial: Error Handling for REST with Spring](https://www.baeldung.com/exception-handling-for-rest-with-spring) you may want to emit logs to the audit log service in case of `AccessDeniedException`s.
 


### PR DESCRIPTION
## Background

My (application dev) team and I currently face the situation that we have a BTP CF application, which is bound to (in total) three different XSUAA service instance.
It is already clarified that Spring Boot AutoConfiguration of `spring-security` will not do the trick. That is why we are trying to overwrite the configuration with our own.
We try to stay as close as possible to the infrastructure cloud-security-services-integration provides/uses to avoid incompatibilities. 

## Current Situation

During our debugging sessions we detected that the incapability of handling more than two XSUAA service instance is not just with AutoConfiguration, but goes deeper - down to the level of handling the `CFEnvironment`. The main problem we identified is located at https://github.com/clnative/cloud-security-services-integration-library/blob/6c6bbb7a38c60da62c4f19aa4985bf795e318c5f/env/src/main/java/com/sap/cloud/security/config/cf/CFEnvironment.java#L188. There an "arbitrary first instance" is selected. However, no sorting is applied before. That is why, depending in which order the service instances are mentioned in environment variable `VCAP_SERVICES` plus some other internal factors, "some" service instance is returned. This arbitrary selection is very nasty - in our case in our test landscapes all tests returned the expected service instance (by chance). As soon as we started to roll out the "validated implementation" to production, the wrong service instance was selected and promptly caused a downtime. 

## Solution Approach

Avoid "arbitrary" selection of the XSUAA/IAS service instances by taking the service instance with the lexicographically lowest CF service instance environment `name`[1]. This makes the selection behavior much more predictable and may even provide a chance for application developers to influence indirectly which service instance will be selected.

After alignment, we discussed to protect this sorting logic behind a configuration option to ensure backward compatibility. The configuration option gets explained in the `spring-security/README.md` file.

## Known Open Questions / Tasks

- [ ] Currently the approach is only thought through for the CF case. K8S cannot be tested by the author (atm). So far, no implementation for the K8S case has been done, as there is too little knowledge about how the situation is there. It needs to be clarified if the same approach shall also be applied there. At the current state of implementation, K8S does not consider any "service instance name" and therefore most likely would yield the old behavior.
- [x] Update of documentation required? Which, where?

## Footnotes

[1] Note that although typically this is the service instance's name (as used when creating the service instance), it may also be overwritten by a binding name. See also section "VCAP_SERVICES" in https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html.