### PR TITLE
Update JwtBearerTokenFlow via cherry-pick for the 2.X token-client version 

### DIFF
--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2TokenServiceConstants.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2TokenServiceConstants.java
@@ -40,7 +40,7 @@ public class OAuth2TokenServiceConstants {
 	public static final String GRANT_TYPE_CLIENT_X509 = "client_x509";
 	public static final String GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code"; // not supported by token-client
 																						// lib
-
+	public static final String TOKEN_FORMAT = "token_format";
 	public static final String TOKEN_TYPE_OPAQUE = "opaque";
 
 	public static final String PARAMETER_CLIENT_ID = "client_id";

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/JwtBearerTokenFlow.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/JwtBearerTokenFlow.java
@@ -146,16 +146,16 @@ public class JwtBearerTokenFlow {
         return this;
     }
 
-	/**
-	 * Can be used to change the format of the returned token.
-	 *
-	 * @param opaque enables opaque token format when set to {@code true}.
-	 * @return this builder.
-	 */
-	public JwtBearerTokenFlow setOpaqueTokenFormat(boolean opaque) {
-		this.opaque = opaque;
-		return this;
-	}
+    /**
+     * Can be used to change the format of the returned token.
+     *
+     * @param opaque enables opaque token format when set to {@code true}.
+     * @return this builder.
+     */
+    public JwtBearerTokenFlow setOpaqueTokenFormat(boolean opaque) {
+	this.opaque = opaque;
+	return this;
+    }
 
     /**
      * Executes this flow against the XSUAA endpoint. As a result the exchanged JWT
@@ -174,11 +174,11 @@ public class JwtBearerTokenFlow {
             throw new IllegalStateException("A bearerToken must be set before executing the flow.");
         }
 
-		if (opaque) {
-			optionalParameters.put(TOKEN_FORMAT, TOKEN_TYPE_OPAQUE);
-		} else {
-			optionalParameters.remove(TOKEN_FORMAT);
-		}
+	if (opaque) {
+		optionalParameters.put(TOKEN_FORMAT, TOKEN_TYPE_OPAQUE);
+	} else {
+		optionalParameters.remove(TOKEN_FORMAT);
+	}
 
         String scopesParameter = String.join(" ", scopes);
         if (!scopesParameter.isEmpty()) {

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/JwtBearerTokenFlow.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/JwtBearerTokenFlow.java
@@ -15,6 +15,8 @@ import java.util.Map;
 import static com.sap.cloud.security.xsuaa.Assertions.assertNotNull;
 import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.AUTHORITIES;
 import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.SCOPE;
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.TOKEN_FORMAT;
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.TOKEN_TYPE_OPAQUE;
 import static com.sap.cloud.security.xsuaa.tokenflows.XsuaaTokenFlowsUtils.buildAdditionalAuthoritiesJson;
 
 /**
@@ -33,6 +35,7 @@ public class JwtBearerTokenFlow {
     private List<String> scopes = new ArrayList<>();
     private String subdomain;
     private boolean disableCache;
+	private boolean opaque = false;
 
     public JwtBearerTokenFlow(@Nonnull OAuth2TokenService tokenService,
                               @Nonnull OAuth2ServiceEndpointsProvider endpointsProvider,
@@ -143,6 +146,17 @@ public class JwtBearerTokenFlow {
         return this;
     }
 
+	/**
+	 * Can be used to change the format of the returned token.
+	 *
+	 * @param opaque enables opaque token format when set to {@code true}.
+	 * @return this builder.
+	 */
+	public JwtBearerTokenFlow setOpaqueTokenFormat(boolean opaque) {
+		this.opaque = opaque;
+		return this;
+	}
+
     /**
      * Executes this flow against the XSUAA endpoint. As a result the exchanged JWT
      * token is returned.
@@ -159,6 +173,12 @@ public class JwtBearerTokenFlow {
         if (bearerToken == null) {
             throw new IllegalStateException("A bearerToken must be set before executing the flow.");
         }
+
+		if (opaque) {
+			optionalParameters.put(TOKEN_FORMAT, TOKEN_TYPE_OPAQUE);
+		} else {
+			optionalParameters.remove(TOKEN_FORMAT);
+		}
 
         String scopesParameter = String.join(" ", scopes);
         if (!scopesParameter.isEmpty()) {

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/JwtBearerTokenFlow.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/JwtBearerTokenFlow.java
@@ -175,9 +175,9 @@ public class JwtBearerTokenFlow {
         }
 
 	if (opaque) {
-		optionalParameters.put(TOKEN_FORMAT, TOKEN_TYPE_OPAQUE);
+	    optionalParameters.put(TOKEN_FORMAT, TOKEN_TYPE_OPAQUE);
 	} else {
-		optionalParameters.remove(TOKEN_FORMAT);
+	    optionalParameters.remove(TOKEN_FORMAT);
 	}
 
         String scopesParameter = String.join(" ", scopes);

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/tokenflows/JwtBearerTokenFlowTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/tokenflows/JwtBearerTokenFlowTest.java
@@ -139,6 +139,32 @@ public class JwtBearerTokenFlowTest {
 				.retrieveAccessTokenViaJwtBearerTokenGrant(any(), any(), any(), any(), any(), eq(false));
 	}
 
+	@Test
+	public void execute_withOpaqueTokenFormat() throws TokenFlowException, OAuth2ServiceException {
+		final String OPAQUE = "opaque";
+		final String TOKEN_FORMAT = "token_format";
+		ArgumentCaptor<Map<String, String>> optionalParametersCaptor = ArgumentCaptor.forClass(Map.class);
+
+		cut.token(exchangeToken).execute();
+		verify(mockTokenService, times(1))
+				.retrieveAccessTokenViaJwtBearerTokenGrant(any(), any(), any(), any(),
+						optionalParametersCaptor.capture(), anyBoolean());
+		assertThat(optionalParametersCaptor.getValue()).doesNotContainEntry(TOKEN_FORMAT, OPAQUE);
+
+
+		cut.setOpaqueTokenFormat(true).execute();
+		verify(mockTokenService, times(2))
+				.retrieveAccessTokenViaJwtBearerTokenGrant(any(), any(), any(), any(),
+						optionalParametersCaptor.capture(), anyBoolean());
+		assertThat(optionalParametersCaptor.getValue()).containsEntry(TOKEN_FORMAT, OPAQUE);
+
+		cut.setOpaqueTokenFormat(false).execute();
+		verify(mockTokenService, times(3))
+				.retrieveAccessTokenViaJwtBearerTokenGrant(any(), any(), any(), any(),
+						optionalParametersCaptor.capture(), anyBoolean());
+		assertThat(optionalParametersCaptor.getValue()).doesNotContainEntry(TOKEN_FORMAT, OPAQUE);
+	}
+
 	 @Test
 	public void execute_withAdditionalAuthorities() throws TokenFlowException, OAuth2ServiceException {
 		OAuth2TokenResponse mockedResponse = mockRetrieveAccessToken();


### PR DESCRIPTION
JwtBearerTokenFlow: add additional setter to request an opaque token response