### PR TITLE
Use Jetty 12 with EE9 with Spring Boot 3.2

### DIFF
--- a/java-security-test/pom.xml
+++ b/java-security-test/pom.xml
@@ -38,24 +38,18 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>jakarta.servlet</groupId>
-					<artifactId>jakarta.servlet-api</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-servlet</artifactId>
+			<groupId>org.eclipse.jetty.ee9</groupId>
+			<artifactId>jetty-ee9-servlet</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-webapp</artifactId>
+			<groupId>org.eclipse.jetty.ee9</groupId>
+			<artifactId>jetty-ee9-webapp</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-annotations</artifactId>
+			<groupId>org.eclipse.jetty.ee9</groupId>
+			<artifactId>jetty-ee9-annotations</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>

--- a/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTest.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTest.java
@@ -29,11 +29,11 @@ import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
 import org.apache.commons.io.IOUtils;
-import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.ee9.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.FilterHolder;
-import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.ee9.servlet.FilterHolder;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
+import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTestRule.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTestRule.java
@@ -14,7 +14,7 @@ import com.sap.cloud.security.test.api.ServiceMockConfiguration;
 import com.sap.cloud.security.token.Token;
 import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
-import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.junit.rules.ExternalResource;
 
 import javax.annotation.Nullable;

--- a/java-security-test/src/main/java/com/sap/cloud/security/test/api/ApplicationServerConfiguration.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/api/ApplicationServerConfiguration.java
@@ -10,7 +10,7 @@ import com.sap.cloud.security.test.ApplicationServerOptions;
 import com.sap.cloud.security.test.SecurityTestRule;
 import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
-import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
 
 public interface ApplicationServerConfiguration {
 

--- a/java-security-test/src/main/java/com/sap/cloud/security/test/extension/SecurityTestExtension.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/extension/SecurityTestExtension.java
@@ -13,7 +13,7 @@ import com.sap.cloud.security.test.api.SecurityTestContext;
 import com.sap.cloud.security.test.api.ServiceMockConfiguration;
 import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
-import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.junit.jupiter.api.extension.*;
 
 /**

--- a/java-security-test/src/main/java/com/sap/cloud/security/test/jetty/JettyTokenAuthenticator.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/jetty/JettyTokenAuthenticator.java
@@ -10,10 +10,10 @@ import com.sap.cloud.security.servlet.TokenAuthenticator;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletResponse;
-import org.eclipse.jetty.security.Authenticator;
-import org.eclipse.jetty.security.DefaultUserIdentity;
-import org.eclipse.jetty.security.UserAuthentication;
-import org.eclipse.jetty.server.Authentication;
+import org.eclipse.jetty.ee9.security.Authenticator;
+import org.eclipse.jetty.ee9.security.UserAuthentication;
+import org.eclipse.jetty.ee9.nested.Authentication;
+import org.eclipse.jetty.security.internal.DefaultUserIdentity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/java-security-test/src/test/java/com/sap/cloud/security/test/SecurityTestRuleTest.java
+++ b/java-security-test/src/test/java/com/sap/cloud/security/test/SecurityTestRuleTest.java
@@ -21,7 +21,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClients;
-import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,20 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-bom</artifactId>
+				<version>${org.eclipse.jetty.bom.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty.ee9</groupId>
+				<artifactId>jetty-ee9-bom</artifactId>
+				<version>${org.eclipse.jetty.bom.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 			<!-- spring -->
 			<!-- BOMs -->
 			<dependency>
@@ -142,21 +156,6 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
-			<dependency>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-bom</artifactId>
-				<version>${org.eclipse.jetty.bom.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.jetty.ee9</groupId>
-				<artifactId>jetty-ee9-bom</artifactId>
-				<version>${org.eclipse.jetty.bom.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-
 			<!-- spring core -->
 			<dependency>
 				<groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,13 +57,12 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.source.plugin.version>3.2.1</maven.source.plugin.version>
 		<!-- make sure that spring core and spring boot versions are compatible-->
-		<spring.boot.version>3.1.6</spring.boot.version>
-		<spring.core.version>6.0.14</spring.core.version>
+		<spring.boot.version>3.2.0</spring.boot.version>
+		<spring.core.version>6.1.1</spring.core.version>
 		<spring.security.version>6.2.0</spring.security.version>
 		<spring.security.oauth2.version>2.5.2.RELEASE</spring.security.oauth2.version>
 		<spring.security.jwt.version>1.1.1.RELEASE</spring.security.jwt.version>
 		<org.eclipse.jetty.bom.version>12.0.4</org.eclipse.jetty.bom.version>
-		<org.eclipse.jetty.version>11.0.18</org.eclipse.jetty.version>
 		<reactor.version>3.6.0</reactor.version>
 		<log4j2.version>2.22.0</log4j2.version>
 		<slf4j.api.version>2.0.9</slf4j.api.version> <!--see also here http://www.slf4j.org/faq.html#changesInVersion18 -->
@@ -146,6 +145,13 @@
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-bom</artifactId>
+				<version>${org.eclipse.jetty.bom.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty.ee9</groupId>
+				<artifactId>jetty-ee9-bom</artifactId>
 				<version>${org.eclipse.jetty.bom.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
@@ -314,21 +320,6 @@
 				<groupId>org.wiremock</groupId>
 				<artifactId>wiremock-standalone</artifactId>
 				<version>${wiremock.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-servlet</artifactId>
-				<version>${org.eclipse.jetty.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-webapp</artifactId>
-				<version>${org.eclipse.jetty.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-annotations</artifactId>
-				<version>${org.eclipse.jetty.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaResourceServerJwkAutoConfigurationTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaResourceServerJwkAutoConfigurationTest.java
@@ -130,10 +130,5 @@ public class XsuaaResourceServerJwkAutoConfigurationTest {
 			return new RestTemplate();
 		}
 
-		@Bean
-		public RestTemplate xsuaaRestOperations() {
-			return new RestTemplate();
-		}
-
 	}
 }

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaTokenFlowAutoConfigurationTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaTokenFlowAutoConfigurationTest.java
@@ -112,10 +112,5 @@ public class XsuaaTokenFlowAutoConfigurationTest {
 			return new RestTemplate();
 		}
 
-		@Bean
-		public RestTemplate xsuaaRestOperations() {
-			return new RestTemplate();
-		}
-
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/SAP/cloud-security-services-integration-library/issues/1368