### PR TITLE
Support DwC - Avoid superflous WARN log messages

### DIFF
--- a/java-security/pom.xml
+++ b/java-security/pom.xml
@@ -114,11 +114,6 @@
 			<version>1.19.0</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency> <!-- check if it's still needed when slf4j-api 1.8 is available -->
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>com.github.stefanbirkner</groupId>
 			<artifactId>system-lambda</artifactId>
@@ -146,6 +141,11 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/java-security/src/main/java/com/sap/cloud/security/servlet/HybridTokenFactory.java
+++ b/java-security/src/main/java/com/sap/cloud/security/servlet/HybridTokenFactory.java
@@ -32,8 +32,8 @@ import static com.sap.cloud.security.token.TokenClaims.XSUAA.EXTERNAL_ATTRIBUTE_
 public class HybridTokenFactory implements TokenFactory {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(HybridTokenFactory.class);
-	protected static Optional<String> xsAppId;
-	protected static ScopeConverter xsScopeConverter;
+	static Optional<String> xsAppId;
+	static ScopeConverter xsScopeConverter;
 
 	/**
 	 * Determines whether the JWT token is issued by XSUAA or IAS identity service,
@@ -84,10 +84,13 @@ public class HybridTokenFactory implements TokenFactory {
 		}
 		OAuth2ServiceConfiguration serviceConfiguration = Environments.getCurrent().getXsuaaConfiguration();
 		if (serviceConfiguration != null) {
-			return xsAppId = Optional.of(serviceConfiguration.getProperty(CFConstants.XSUAA.APP_ID));
+			xsAppId = Optional.of(serviceConfiguration.getProperty(CFConstants.XSUAA.APP_ID));
+		} else {
+			LOGGER.warn(
+					"There is no xsuaa service configuration with 'xsappname' property: no local scope check possible.");
+			xsAppId = Optional.empty();
 		}
-		LOGGER.warn("There is no xsuaa service configuration with 'xsappname' property: no local scope check possible.");
-		return xsAppId = Optional.empty();
+		return xsAppId;
 	}
 
 	/**

--- a/java-security/src/main/java/com/sap/cloud/security/servlet/HybridTokenFactory.java
+++ b/java-security/src/main/java/com/sap/cloud/security/servlet/HybridTokenFactory.java
@@ -32,8 +32,8 @@ import static com.sap.cloud.security.token.TokenClaims.XSUAA.EXTERNAL_ATTRIBUTE_
 public class HybridTokenFactory implements TokenFactory {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(HybridTokenFactory.class);
-	private static Optional<String> xsAppId;
-	private static ScopeConverter xsScopeConverter;
+	protected static Optional<String> xsAppId;
+	protected static ScopeConverter xsScopeConverter;
 
 	/**
 	 * Determines whether the JWT token is issued by XSUAA or IAS identity service,

--- a/java-security/src/test/java/com/sap/cloud/security/servlet/HybridTokenFactoryTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/servlet/HybridTokenFactoryTest.java
@@ -1,0 +1,48 @@
+package com.sap.cloud.security.servlet;
+
+import ch.qos.logback.core.read.ListAppender;
+import com.sap.cloud.security.token.XsuaaToken;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.Logger;
+
+import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class HybridTokenFactoryTest {
+
+    private ListAppender<ILoggingEvent> logWatcher;
+    private HybridTokenFactory cut;
+
+    @BeforeEach
+    public void setup() {
+        cut = new HybridTokenFactory();
+            logWatcher = new ListAppender<>();
+            logWatcher.start();
+            ((Logger) LoggerFactory.getLogger(HybridTokenFactory.class)).addAppender(logWatcher);
+    }
+
+    @AfterEach
+    void teardown() {
+        ((Logger) LoggerFactory.getLogger(HybridTokenFactory.class)).detachAndStopAllAppenders();
+    }
+
+    @Test
+    void oneWarningMessageIncaseSecurityConfigIsMissing() throws IOException {
+        String jwt = IOUtils.resourceToString("/xsuaaUserAccessTokenRSA256.txt", UTF_8);
+        XsuaaToken token = (XsuaaToken) cut.create(jwt);
+        cut.create(jwt);
+
+        assertThat(token.getIssuer()).isEqualTo("http://auth.com");
+        assertThrows(IllegalArgumentException.class, () -> token.hasLocalScope("abc"));
+        assertThat(logWatcher.list).isNotNull().hasSize(1);
+        assertThat(logWatcher.list.get(0).getMessage()).contains("There is no xsuaa service configuration");
+    }
+}

--- a/java-security/src/test/java/com/sap/cloud/security/servlet/HybridTokenFactoryTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/servlet/HybridTokenFactoryTest.java
@@ -24,9 +24,11 @@ class HybridTokenFactoryTest {
     @BeforeEach
     public void setup() {
         cut = new HybridTokenFactory();
-            logWatcher = new ListAppender<>();
-            logWatcher.start();
-            ((Logger) LoggerFactory.getLogger(HybridTokenFactory.class)).addAppender(logWatcher);
+        cut.xsAppId = null;
+        cut.xsScopeConverter = null;
+        logWatcher = new ListAppender<>();
+        logWatcher.start();
+        ((Logger) LoggerFactory.getLogger(HybridTokenFactory.class)).addAppender(logWatcher);
     }
 
     @AfterEach


### PR DESCRIPTION
In case of DwC setup, there is no need to have an xsuaa service bound to the cloud foundry application. Token is validated in the jupiter component. Therefore, the WARN log should be written a single time time, and not every time the token gets created via `HybridTokenFactory`.

With that change the log messages looks as following (spring-security-hybrid-usage sample - TestControllerTest.sayHello()):

````
2024-01-02 16:03:14.873  WARN 19633 --- [           main] c.s.c.s.servlet.HybridTokenFactory       : There is no xsuaa service configuration with 'xsappname' property: no local scope check possible.
2024-01-02 16:03:36.415  INFO 19633 --- [           main] c.s.c.s.t.v.v.XsuaaJwtSignatureValidator : Loaded custom JKU factory
2024-01-02 16:03:56.008  INFO 19633 --- [           main] c.s.c.security.client.HttpClientFactory  : loaded HttpClientFactory service providers: [com.sap.cloud.security.client.DefaultHttpClientFactory@696298ea]
2024-01-02 16:03:56.176  INFO 19633 --- [           main] c.s.c.s.t.v.v.JwtAudienceValidator       : The audiences that are derived from the token: [sb-clientId!t0815].
2024-01-02 16:03:59.714  WARN 19633 --- [           main] com.sap.cloud.security.token.XsuaaToken  : origin claim not set in JWT. Cannot create unique user name. Returning null.
2024-01-02 16:03:59.715  INFO 19633 --- [           main] c.s.h.c.l.servlet.filter.RequestLogger   : {"request":"/sayHello","referer":"-","response_sent_at":"2024-01-02T15:03:59.715030Z","response_status":200,"method":"GET","response_size_b":276,"request_size_b":-1,"remote_port":"redacted","layer":"[SERVLET]","remote_host":"redacted","remote_user":"-","protocol":"HTTP/1.1","remote_ip":"redacted","response_content_type":"application/json","request_received_at":"2024-01-02T15:02:35.038165Z","response_time_ms":84676.865,"direction":"IN"}
2024-01-02 16:03:59.725  INFO 19633 --- [           main] Spring Security Debugger       
````          