### PR TITLE
Fix for usage of WebServlet annotation in java-security-test

### DIFF
--- a/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTest.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTest.java
@@ -28,16 +28,23 @@ import com.sap.cloud.security.xsuaa.http.MediaType;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletContext;
 import org.apache.commons.io.IOUtils;
+import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.ee10.servlet.FilterHolder;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.ee10.webapp.Configuration;
+import org.eclipse.jetty.ee10.webapp.Configurations;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
+import org.eclipse.jetty.ee10.webapp.WebXmlConfiguration;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -229,8 +236,13 @@ public class SecurityTest
 
 		WebAppContext context = new WebAppContext();
 		context.setContextPath("/");
-		context.setBaseResourceAsString("src/main/webapp");
 		context.setSecurityHandler(security);
+		File file = new File("src/main/webapp");
+		if (file.exists() && file.isDirectory()) {
+			context.setBaseResourceAsString("src/main/webapp");
+		} else {
+			context.setBaseResourceAsString("src/main/java");
+		}
 
 		applicationServletsByPath
 				.forEach((path, servletHolder) -> context.addServlet(servletHolder, path));

--- a/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTest.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTest.java
@@ -28,18 +28,12 @@ import com.sap.cloud.security.xsuaa.http.MediaType;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
-import jakarta.servlet.ServletContext;
 import org.apache.commons.io.IOUtils;
-import org.eclipse.jetty.annotations.AnnotationConfiguration;
 import org.eclipse.jetty.ee10.servlet.FilterHolder;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintSecurityHandler;
-import org.eclipse.jetty.ee10.webapp.Configuration;
-import org.eclipse.jetty.ee10.webapp.Configurations;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
-import org.eclipse.jetty.ee10.webapp.WebXmlConfiguration;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.util.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/samples/java-security-usage-ias/pom.xml
+++ b/samples/java-security-usage-ias/pom.xml
@@ -17,7 +17,7 @@
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <jakarta.servlet.api.version>6.0.0</jakarta.servlet.api.version>
         <assertj.version>3.24.2</assertj.version>
-        <junit.version>5.9.2</junit.version>
+        <junit.version>5.10.0</junit.version>
     </properties>
 
     <dependencyManagement>
@@ -65,6 +65,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>

--- a/samples/java-security-usage-ias/pom.xml
+++ b/samples/java-security-usage-ias/pom.xml
@@ -93,6 +93,11 @@
                     <warName>java-security-usage-ias</warName>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/samples/java-security-usage/pom.xml
+++ b/samples/java-security-usage/pom.xml
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.2.5</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
In the sample libraries that used the @WebServlet annotation the tests didn't work. 
I made changes in the java-security-test library so that the base resource path of WebAppContext is now set dynamically based on the existence of a web.xml file. 