### PR TITLE
feat: Add IAS Credential Types

### DIFF
--- a/java-api/src/main/java/com/sap/cloud/security/config/CredentialType.java
+++ b/java-api/src/main/java/com/sap/cloud/security/config/CredentialType.java
@@ -11,7 +11,8 @@ import javax.annotation.Nullable;
  * Constants denoting the credential types of identity OAuth2 configuration
  */
 public enum CredentialType {
-	X509("x509"), INSTANCE_SECRET("instance-secret"), BINDING_SECRET("binding-secret");
+	X509("x509"), INSTANCE_SECRET("instance-secret"), BINDING_SECRET("binding-secret"),
+	X509_GENERATED("X509_GENERATED"), X509_PROVIDED("X509_PROVIDED"), X509_ATTESTED("X509_ATTESTED");
 
 	private final String typeName;
 

--- a/java-api/src/test/java/com/sap/cloud/security/config/CredentialTypeTest.java
+++ b/java-api/src/test/java/com/sap/cloud/security/config/CredentialTypeTest.java
@@ -13,6 +13,9 @@ public class CredentialTypeTest {
 	@Test
 	public void from() {
 		Assert.assertEquals(CredentialType.X509, CredentialType.from("x509"));
+		Assert.assertEquals(CredentialType.X509_GENERATED, CredentialType.from("X509_GENERATED"));
+		Assert.assertEquals(CredentialType.X509_PROVIDED, CredentialType.from("X509_PROVIDED"));
+		Assert.assertEquals(CredentialType.X509_ATTESTED, CredentialType.from("X509_ATTESTED"));
 		Assert.assertEquals(CredentialType.INSTANCE_SECRET, CredentialType.from("instance-secret"));
 		Assert.assertEquals(CredentialType.BINDING_SECRET, CredentialType.from("binding-secret"));
 	}

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
@@ -52,11 +52,11 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 	public XsuaaDefaultEndpoints(@Nonnull OAuth2ServiceConfiguration config) {
 		assertNotNull(config, "OAuth2ServiceConfiguration must not be null.");
 		this.baseUri = config.getUrl();
-		if (config.getCredentialType() == CredentialType.X509) {
-			this.certUri = config.getCertUrl();
-		} else {
-			this.certUri = null;
-		}
+		final CredentialType credentialType = config.getCredentialType() != null ? config.getCredentialType() : CredentialType.BINDING_SECRET;
+		this.certUri = switch (credentialType) {
+			case X509, X509_GENERATED, X509_PROVIDED, X509_ATTESTED -> config.getCertUrl();
+			case BINDING_SECRET, INSTANCE_SECRET -> null;
+		};
 	}
 
 	@Override


### PR DESCRIPTION
This PR recognizes the credential types of IAS service bindings in the enum.