### PR TITLE
Fix for IAT Claim in ReactiveHybridJwtDecoder

### DIFF
--- a/java-security-test/src/main/java/com/sap/cloud/security/test/JwtGenerator.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/JwtGenerator.java
@@ -216,8 +216,7 @@ public class JwtGenerator {
 	}
 
 	/**
-	 * Sets the claim with the given name to the given integer value. Note: for overwriting client Id claim, "azp" claim
-	 * value should be overwritten instead of deprecated "cid"
+	 * Sets the claim with the given name to the given integer value.
 	 *
 	 * @param claimName
 	 * 		the name of the claim to be set.

--- a/java-security-test/src/main/java/com/sap/cloud/security/test/JwtGenerator.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/JwtGenerator.java
@@ -216,6 +216,21 @@ public class JwtGenerator {
 	}
 
 	/**
+	 * Sets the claim with the given name to the given integer value. Note: for overwriting client Id claim, "azp" claim
+	 * value should be overwritten instead of deprecated "cid"
+	 *
+	 * @param claimName
+	 * 		the name of the claim to be set.
+	 * @param value
+	 * 		the integer value of the claim to be set.
+	 * @return the builder object.
+	 */
+	public JwtGenerator withClaimValue(String claimName, int value) {
+		jsonPayload.put(claimName, value);
+		return this;
+	}
+
+	/**
 	 * Sets the claim with the given name to the given string value. Note: for overwriting client Id claim, "azp" claim
 	 * value should be overwritten instead of deprecated "cid"
 	 *

--- a/spring-security/Migration_SpringXsuaaProjects.md
+++ b/spring-security/Migration_SpringXsuaaProjects.md
@@ -50,7 +50,7 @@ public class SecurityConfiguration {
 ```
 
 ## Access VCAP_SERVICES values
-```spring-security``` automatically maps the `VCAP_SERVICES` credentials to Spring properties. Please note that the **prefix has changed** from ```xsuaa.*``` to ```sap.security.services.xsuaa``` or ```sap.security.services.xsuaa[0]``` in case of multiple xsuaa service bindings. Please find a sample property file [here](/samples/spring-security-hybrid-usage/src/test/resources/application-multixsuaa.yml).  
+```spring-security``` automatically maps the `VCAP_SERVICES` credentials to Spring properties. Please note that the **prefix has changed** from ```xsuaa.*``` to ```sap.security.services.xsuaa``` or ```sap.security.services.xsuaa[0]``` in case of multiple xsuaa service bindings. Please find a sample property file [here](/samples/spring-security-hybrid-usage/src/test/resources/application.yml).  
 
 #### ``@Value``
   **Before**  

--- a/spring-security/src/main/java/com/sap/cloud/security/spring/token/authentication/ReactiveHybridJwtDecoder.java
+++ b/spring-security/src/main/java/com/sap/cloud/security/spring/token/authentication/ReactiveHybridJwtDecoder.java
@@ -66,7 +66,7 @@ public class ReactiveHybridJwtDecoder implements ReactiveJwtDecoder {
     static Mono<Jwt> parseJwt(Token token) {
         try{
             Instant issuedAt = token.hasClaim(TokenClaims.XSUAA.ISSUED_AT)
-                    ? Instant.ofEpochSecond(Long.parseLong(token.getClaimAsString(TokenClaims.XSUAA.ISSUED_AT)))
+                    ? Instant.ofEpochSecond(Long.parseLong(token.getClaims().get("iat").toString()))
                     : null;
             return Mono.just(new Jwt(token.getTokenValue(), issuedAt,
                     token.getExpiration(), token.getHeaders(), token.getClaims()));

--- a/spring-security/src/main/java/com/sap/cloud/security/spring/token/authentication/ReactiveHybridJwtDecoder.java
+++ b/spring-security/src/main/java/com/sap/cloud/security/spring/token/authentication/ReactiveHybridJwtDecoder.java
@@ -66,7 +66,7 @@ public class ReactiveHybridJwtDecoder implements ReactiveJwtDecoder {
     static Mono<Jwt> parseJwt(Token token) {
         try{
             Instant issuedAt = token.hasClaim(TokenClaims.XSUAA.ISSUED_AT)
-                    ? Instant.ofEpochSecond(Long.parseLong(token.getClaims().get("iat").toString()))
+                    ? Instant.ofEpochSecond(Long.parseLong(token.getClaims().get(TokenClaims.XSUAA.ISSUED_AT).toString()))
                     : null;
             return Mono.just(new Jwt(token.getTokenValue(), issuedAt,
                     token.getExpiration(), token.getHeaders(), token.getClaims()));

--- a/spring-security/src/test/java/com/sap/cloud/security/spring/token/authentication/ReactiveHybridJwtDecoderTest.java
+++ b/spring-security/src/test/java/com/sap/cloud/security/spring/token/authentication/ReactiveHybridJwtDecoderTest.java
@@ -52,6 +52,7 @@ class ReactiveHybridJwtDecoderTest {
 
 		assertEquals("theClientId", cut.decode(encodedToken).block().getClaim(TokenClaims.AUTHORIZATION_PARTY));
         assertTrue(jwtToken.hasClaim(TokenClaims.XSUAA.ISSUED_AT));
+		assertEquals(1704067200, jwtToken.getClaims().get(TokenClaims.XSUAA.ISSUED_AT));
 	}
 
 	@Test

--- a/spring-security/src/test/java/com/sap/cloud/security/spring/token/authentication/ReactiveHybridJwtDecoderTest.java
+++ b/spring-security/src/test/java/com/sap/cloud/security/spring/token/authentication/ReactiveHybridJwtDecoderTest.java
@@ -36,7 +36,7 @@ class ReactiveHybridJwtDecoderTest {
 	}
 
 	@Test
-	void parseJwt() {
+	void parseJwtIasToken() {
 		Jwt jwtToken = ReactiveHybridJwtDecoder.parseJwt(jwtGenerator.createToken()).block();
 
 		assertEquals(2, jwtToken.getHeaders().size());
@@ -44,6 +44,18 @@ class ReactiveHybridJwtDecoderTest {
 		assertEquals(1, jwtToken.getExpiresAt().compareTo(Instant.now()));
 		assertEquals("theClientId", jwtToken.getClaims().get(TokenClaims.AUTHORIZATION_PARTY));
 
+	}
+
+	@Test
+	void parseJwtXsuaaToken() {
+		JwtGenerator jwtGeneratorXsuaa = JwtGenerator.getInstance(XSUAA, "theClientId").withClaimValue("iat", "1704063600");
+
+		Jwt jwtToken = ReactiveHybridJwtDecoder.parseJwt(jwtGeneratorXsuaa.createToken()).block();
+
+		assertEquals(3, jwtToken.getHeaders().size());
+		assertEquals(7, jwtToken.getClaims().size());
+		assertEquals(1, jwtToken.getExpiresAt().compareTo(Instant.now()));
+		assertEquals("theClientId", jwtToken.getClaims().get(TokenClaims.AUTHORIZATION_PARTY));
 	}
 
 	@Test

--- a/spring-security/src/test/java/com/sap/cloud/security/spring/token/authentication/ReactiveHybridJwtDecoderTest.java
+++ b/spring-security/src/test/java/com/sap/cloud/security/spring/token/authentication/ReactiveHybridJwtDecoderTest.java
@@ -15,8 +15,7 @@ import java.time.Instant;
 
 import static com.sap.cloud.security.config.Service.IAS;
 import static com.sap.cloud.security.config.Service.XSUAA;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -48,9 +47,11 @@ class ReactiveHybridJwtDecoderTest {
 
 	@Test
 	void decodeXsuaaTokenWithIatClaim() {
-		String encodedToken = JwtGenerator.getInstance(XSUAA, "theClientId").withClaimValue("iat", "1704067200").createToken().getTokenValue();
+		Token jwtToken = JwtGenerator.getInstance(XSUAA, "theClientId").withClaimValue(TokenClaims.XSUAA.ISSUED_AT, 1704067200).createToken();
+		String encodedToken = jwtToken.getTokenValue();
 
 		assertEquals("theClientId", cut.decode(encodedToken).block().getClaim(TokenClaims.AUTHORIZATION_PARTY));
+        assertTrue(jwtToken.hasClaim(TokenClaims.XSUAA.ISSUED_AT));
 	}
 
 	@Test

--- a/spring-security/src/test/java/com/sap/cloud/security/spring/token/authentication/ReactiveHybridJwtDecoderTest.java
+++ b/spring-security/src/test/java/com/sap/cloud/security/spring/token/authentication/ReactiveHybridJwtDecoderTest.java
@@ -36,7 +36,7 @@ class ReactiveHybridJwtDecoderTest {
 	}
 
 	@Test
-	void parseJwtIasToken() {
+	void parseJwt() {
 		Jwt jwtToken = ReactiveHybridJwtDecoder.parseJwt(jwtGenerator.createToken()).block();
 
 		assertEquals(2, jwtToken.getHeaders().size());
@@ -47,15 +47,10 @@ class ReactiveHybridJwtDecoderTest {
 	}
 
 	@Test
-	void parseJwtXsuaaToken() {
-		JwtGenerator jwtGeneratorXsuaa = JwtGenerator.getInstance(XSUAA, "theClientId").withClaimValue("iat", "1704063600");
+	void decodeXsuaaTokenWithIatClaim() {
+		String encodedToken = JwtGenerator.getInstance(XSUAA, "theClientId").withClaimValue("iat", "1704067200").createToken().getTokenValue();
 
-		Jwt jwtToken = ReactiveHybridJwtDecoder.parseJwt(jwtGeneratorXsuaa.createToken()).block();
-
-		assertEquals(3, jwtToken.getHeaders().size());
-		assertEquals(7, jwtToken.getClaims().size());
-		assertEquals(1, jwtToken.getExpiresAt().compareTo(Instant.now()));
-		assertEquals("theClientId", jwtToken.getClaims().get(TokenClaims.AUTHORIZATION_PARTY));
+		assertEquals("theClientId", cut.decode(encodedToken).block().getClaim(TokenClaims.AUTHORIZATION_PARTY));
 	}
 
 	@Test


### PR DESCRIPTION
IAT Claim (IssuedAt Claim) in XSUAA Token is numeric but was tried to read as a String. Fixes #1490