### PR TITLE
Update spring-core to 5.3.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## 2.17.4
+## 2.17.5
 
 #### Dependency upgrades
 
 - bump spring-core version to 5.3.34
+
+## 2.17.4
+
+#### Dependency upgrades
+
+- bump spring-core version to 5.3.33
 - bump spring-security version to 5.8.11
 - bump og4j2.version to 2.23.1
 - bump commons io version to 2.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 #### Dependency upgrades
 
-- bump spring-core version to 5.3.33
+- bump spring-core version to 5.3.34
 - bump spring-security version to 5.8.11
 - bump og4j2.version to 2.23.1
 - bump commons io version to 2.16.1

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 		<maven.source.plugin.version>3.2.1</maven.source.plugin.version>
 		<!-- make sure that spring core and spring boot versions are compatible-->
 		<spring.boot.version>2.7.18</spring.boot.version>
-		<spring.core.version>5.3.33</spring.core.version>
+		<spring.core.version>5.3.34</spring.core.version>
 		<spring.security.version>5.8.11</spring.security.version>
 		<spring.security.oauth2.version>2.5.2.RELEASE</spring.security.oauth2.version>
 		<spring.security.jwt.version>1.1.1.RELEASE</spring.security.jwt.version>


### PR DESCRIPTION
Hello colleagues,
There is a Spring Framework security vulnerability [(BDSA-2024-1160)](https://sap.blackducksoftware.com/api/vulnerabilities/BDSA-2024-1160/overview)  on version `5.3.33`.
I updated `spring-core` to `5.3.34`

Is is possible to have a timeline for the release of `2.17.5` so we can plan our next release of the SAP Cloud SDK?
