### PR TITLE
Improve the custom SecurityContext Strategy registration

### DIFF
--- a/spring-security/src/main/java/com/sap/cloud/security/spring/autoconfig/SecurityContextAutoConfiguration.java
+++ b/spring-security/src/main/java/com/sap/cloud/security/spring/autoconfig/SecurityContextAutoConfiguration.java
@@ -5,14 +5,17 @@
  */
 package com.sap.cloud.security.spring.autoconfig;
 
-import org.springframework.beans.factory.config.MethodInvokingFactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
+
+import com.sap.cloud.security.spring.token.authentication.JavaSecurityContextHolderStrategy;
 
 /**
  * {@link EnableAutoConfiguration} uses a
@@ -24,18 +27,14 @@ import org.springframework.security.core.context.SecurityContextHolderStrategy;
  * property {@code sap.spring.security.hybrid.auto = false}.
  */
 @Configuration
-@ConditionalOnProperty(name = "sap.spring.security.hybrid.auto", havingValue = "true", matchIfMissing = true)
-public class SecurityContextAutoConfiguration {
+@ConditionalOnProperty(name = { "sap.spring.security.hybrid.auto", "sap.spring.security.hybrid.sync_securitycontext"}, havingValue = "true", matchIfMissing = true)
+@ConditionalOnMissingBean(SecurityContextHolderStrategy.class)
+@AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE) // ensures that bean is initialized before other configurations
+public class SecurityContextAutoConfiguration implements InitializingBean {
 
-	@Bean
-	@ConditionalOnMissingBean(SecurityContextHolderStrategy.class)
-	@ConditionalOnProperty(name = "sap.spring.security.hybrid.sync_securitycontext", havingValue = "true", matchIfMissing = true)
-	public MethodInvokingFactoryBean methodInvokingFactoryBean() {
-		MethodInvokingFactoryBean methodInvokingFactoryBean = new MethodInvokingFactoryBean();
-		methodInvokingFactoryBean.setTargetClass(SecurityContextHolder.class);
-		methodInvokingFactoryBean.setTargetMethod("setStrategyName");
-		methodInvokingFactoryBean
-				.setArguments("com.sap.cloud.security.spring.token.authentication.JavaSecurityContextHolderStrategy");
-		return methodInvokingFactoryBean;
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		SecurityContextHolder.setContextHolderStrategy(new JavaSecurityContextHolderStrategy());
 	}
+
 }

--- a/spring-security/src/main/java/com/sap/cloud/security/spring/autoconfig/SecurityContextAutoConfiguration.java
+++ b/spring-security/src/main/java/com/sap/cloud/security/spring/autoconfig/SecurityContextAutoConfiguration.java
@@ -6,10 +6,13 @@
 package com.sap.cloud.security.spring.autoconfig;
 
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,6 +20,8 @@ import org.springframework.security.core.context.SecurityContextHolderStrategy;
 
 import com.sap.cloud.security.spring.token.authentication.JavaSecurityContextHolderStrategy;
 
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
 /**
  * {@link EnableAutoConfiguration} uses a
  * {@link com.sap.cloud.security.spring.token.authentication.JavaSecurityContextHolderStrategy}, which keeps the
@@ -27,14 +32,37 @@ import com.sap.cloud.security.spring.token.authentication.JavaSecurityContextHol
  * property {@code sap.spring.security.hybrid.auto = false}.
  */
 @Configuration
-@ConditionalOnProperty(name = { "sap.spring.security.hybrid.auto", "sap.spring.security.hybrid.sync_securitycontext"}, havingValue = "true", matchIfMissing = true)
-@ConditionalOnMissingBean(SecurityContextHolderStrategy.class)
-@AutoConfigureOrder(Ordered.HIGHEST_PRECEDENCE) // ensures that bean is initialized before other configurations
-public class SecurityContextAutoConfiguration implements InitializingBean {
+@ConditionalOnProperty(name = "sap.spring.security.hybrid.auto", havingValue = "true", matchIfMissing = true)
+@ConditionalOnWebApplication
+@ConditionalOnClass(ServletContextInitializer.class)
+public class SecurityContextAutoConfiguration {
 
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		SecurityContextHolder.setContextHolderStrategy(new JavaSecurityContextHolderStrategy());
+	@Bean
+	@ConditionalOnMissingBean(SecurityContextHolderStrategy.class)
+	@ConditionalOnProperty(name = "sap.spring.security.hybrid.sync_securitycontext", havingValue = "true", matchIfMissing = true)
+	SecurityContextSetter securityContextSetter() {
+		return new SecurityContextSetter();
+	}
+
+	static class SecurityContextSetter implements InitializingBean, ServletContextInitializer, Ordered {
+
+		@Override
+		public void afterPropertiesSet() throws Exception {
+			if (!(SecurityContextHolder.getContextHolderStrategy() instanceof JavaSecurityContextHolderStrategy)) {
+				SecurityContextHolder.setContextHolderStrategy(new JavaSecurityContextHolderStrategy());
+			}
+		}
+
+		@Override
+		public void onStartup(ServletContext servletContext) throws ServletException {
+			// empty, used to hook early into the initialization phase
+		}
+
+		@Override
+		public int getOrder() {
+			return Ordered.HIGHEST_PRECEDENCE;
+		}
+
 	}
 
 }

--- a/spring-security/src/test/java/com/sap/cloud/security/spring/autoconfig/SecurityContextAutoConfigurationTest.java
+++ b/spring-security/src/test/java/com/sap/cloud/security/spring/autoconfig/SecurityContextAutoConfigurationTest.java
@@ -29,7 +29,7 @@ class SecurityContextAutoConfigurationTest {
 	@Test
 	void autoConfigurationActiveByDefault() {
 		runner.run(context -> {
-			assertNotNull(context.getBean("securityContextAutoConfiguration"));
+			assertNotNull(context.getBean("securityContextSetter"));
 			assertEquals(JavaSecurityContextHolderStrategy.class,
 					SecurityContextHolder.getContextHolderStrategy().getClass());
 		});
@@ -38,32 +38,32 @@ class SecurityContextAutoConfigurationTest {
 	@Test
 	void autoConfigurationDisabledByProperty() {
 		runner.withPropertyValues("sap.spring.security.hybrid.auto:false")
-				.run((context) -> assertFalse(context.containsBean("securityContextAutoConfiguration")));
+				.run((context) -> assertFalse(context.containsBean("securityContextSetter")));
 	}
 
 	@Test
 	void autoConfigurationDisabledBySpecificProperty() {
 		runner.withPropertyValues("sap.spring.security.hybrid.sync_securitycontext:false")
-				.run((context) -> assertFalse(context.containsBean("securityContextAutoConfiguration")));
+				.run((context) -> assertFalse(context.containsBean("securityContextSetter")));
 	}
 
 	@Test
 	void autoConfigurationEnabledByProperty() {
 		runner.withPropertyValues("sap.spring.security.hybrid.auto:true")
-				.run((context) -> assertTrue(context.containsBean("securityContextAutoConfiguration")));
+				.run((context) -> assertTrue(context.containsBean("securityContextSetter")));
 	}
 
 	@Test
 	void autoConfigurationEnabledBySpecificProperty() {
 		runner.withPropertyValues("sap.spring.security.hybrid.sync_securitycontext:true")
-				.run((context) -> assertTrue(context.containsBean("securityContextAutoConfiguration")));
+				.run((context) -> assertTrue(context.containsBean("securityContextSetter")));
 	}
 
 	@Test
 	void userConfigurationCanOverrideDefaultBeans() {
 		runner.withUserConfiguration(UserConfiguration.class)
 				.run((context) -> {
-					assertFalse(context.containsBean("securityContextAutoConfiguration"));
+					assertFalse(context.containsBean("securityContextSetter"));
 					assertNotNull(context.getBean("customStrategy", SecurityContextHolderStrategy.class));
 					assertNotEquals(JavaSecurityContextHolderStrategy.class,
 							SecurityContextHolder.getContextHolderStrategy().getClass());

--- a/spring-security/src/test/java/com/sap/cloud/security/spring/autoconfig/SecurityContextAutoConfigurationTest.java
+++ b/spring-security/src/test/java/com/sap/cloud/security/spring/autoconfig/SecurityContextAutoConfigurationTest.java
@@ -5,7 +5,12 @@
  */
 package com.sap.cloud.security.spring.autoconfig;
 
-import com.sap.cloud.security.spring.token.authentication.JavaSecurityContextHolderStrategy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
@@ -14,18 +19,17 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
 
-import static org.junit.jupiter.api.Assertions.*;
+import com.sap.cloud.security.spring.token.authentication.JavaSecurityContextHolderStrategy;
 
 class SecurityContextAutoConfigurationTest {
 
 	private final WebApplicationContextRunner runner = new WebApplicationContextRunner()
-			.withPropertyValues("sap.spring.security.hybrid.sync_securitycontext:true")
 			.withConfiguration(AutoConfigurations.of(SecurityContextAutoConfiguration.class));
 
 	@Test
-	void autoConfigurationActive() {
+	void autoConfigurationActiveByDefault() {
 		runner.run(context -> {
-			assertNotNull(context.getBean("methodInvokingFactoryBean"));
+			assertNotNull(context.getBean("securityContextAutoConfiguration"));
 			assertEquals(JavaSecurityContextHolderStrategy.class,
 					SecurityContextHolder.getContextHolderStrategy().getClass());
 		});
@@ -34,20 +38,32 @@ class SecurityContextAutoConfigurationTest {
 	@Test
 	void autoConfigurationDisabledByProperty() {
 		runner.withPropertyValues("sap.spring.security.hybrid.auto:false")
-				.run((context) -> assertFalse(context.containsBean("methodInvokingFactoryBean")));
+				.run((context) -> assertFalse(context.containsBean("securityContextAutoConfiguration")));
+	}
+
+	@Test
+	void autoConfigurationDisabledBySpecificProperty() {
+		runner.withPropertyValues("sap.spring.security.hybrid.sync_securitycontext:false")
+				.run((context) -> assertFalse(context.containsBean("securityContextAutoConfiguration")));
 	}
 
 	@Test
 	void autoConfigurationEnabledByProperty() {
 		runner.withPropertyValues("sap.spring.security.hybrid.auto:true")
-				.run((context) -> assertTrue(context.containsBean("methodInvokingFactoryBean")));
+				.run((context) -> assertTrue(context.containsBean("securityContextAutoConfiguration")));
+	}
+
+	@Test
+	void autoConfigurationEnabledBySpecificProperty() {
+		runner.withPropertyValues("sap.spring.security.hybrid.sync_securitycontext:true")
+				.run((context) -> assertTrue(context.containsBean("securityContextAutoConfiguration")));
 	}
 
 	@Test
 	void userConfigurationCanOverrideDefaultBeans() {
 		runner.withUserConfiguration(UserConfiguration.class)
 				.run((context) -> {
-					assertFalse(context.containsBean("methodInvokingFactoryBean"));
+					assertFalse(context.containsBean("securityContextAutoConfiguration"));
 					assertNotNull(context.getBean("customStrategy", SecurityContextHolderStrategy.class));
 					assertNotEquals(JavaSecurityContextHolderStrategy.class,
 							SecurityContextHolder.getContextHolderStrategy().getClass());


### PR DESCRIPTION
The library now registers a security context strategy by default. In CAP Java we ran into situations where this registration happened too late. The effect of this was, that SecurityConfigs used an obsolete SecurityContextStrategy (which stored by Spring Security as a member variable in the SecurityConfig) and the library set a new strategy in the static holder class. As the SecurityConfigs stored the authentication objects in the obsolete strategy, CAP wasn't able anymore to get the current authentication from the static holder class.

This PR tries to avoid this situation, by ensuring that the auto-configuration has a high precedence and is run early in the application initialization. Additional this PR avoids reflection usage to set the strategy, as reflection is not really required.