### PR TITLE
Support validation of user_token GrantType tokens

### DIFF
--- a/java-api/src/main/java/com/sap/cloud/security/token/GrantType.java
+++ b/java-api/src/main/java/com/sap/cloud/security/token/GrantType.java
@@ -19,6 +19,11 @@ public enum GrantType {
 	JWT_BEARER("urn:ietf:params:oauth:grant-type:jwt-bearer"),
 	SAML2_BEARER("urn:ietf:params:oauth:grant-type:saml2-bearer"),
 	/**
+	 * @deprecated in favor of {@link #JWT_BEARER}.
+	 */
+	@Deprecated
+	USER_TOKEN("user_token"),
+	/**
 	 * @deprecated SAP proprietary grant type.
 	 */
 	@Deprecated


### PR DESCRIPTION
Add user_token again to GrantType enum to prevent errors in applications validating tokens granted by this grant_type.