### PR TITLE
Remove new X5tCertificateThumbprintValidator from spring-xsuaa module

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoderBuilder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoderBuilder.java
@@ -6,12 +6,6 @@
 package com.sap.cloud.security.xsuaa.token.authentication;
 
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -19,6 +13,9 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.web.client.RestOperations;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class XsuaaJwtDecoderBuilder {
 

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoderBuilder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoderBuilder.java
@@ -6,16 +6,19 @@
 package com.sap.cloud.security.xsuaa.token.authentication;
 
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.web.client.RestOperations;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 public class XsuaaJwtDecoderBuilder {
 
@@ -64,7 +67,7 @@ public class XsuaaJwtDecoderBuilder {
 
 	private DelegatingOAuth2TokenValidator<Jwt> getValidators() {
 		return new DelegatingOAuth2TokenValidator<>(new DelegatingOAuth2TokenValidator<>(xsuaaTokenValidators),
-				JwtValidators.createDefault());
+				new JwtTimestampValidator());
 	}
 
 	/**


### PR DESCRIPTION
spring-security has added a new x5t certificate thumbprint validator to the list of default validators:
https://github.com/spring-projects/spring-security/commit/644cfa9f875409d2b2bf01cd791d1a906e44c500#diff-a4724ab787f6f0344a9ab4d3d8f1ce9b0cd16f0b24a51d497b3290b41ed43a04R70-R73

This new validator is automatically getting used in the XsuaaJwtDecoder of the spring-xsuaa module of this lib once consumers update to a newer spring-security version.
This validator does not work for typical usage scenarios of this lib without further configuration because it expects a client certificate in the request. As TLS termination is done earlier by BTP and the certificate is instead forwarded in a header that is not used by the new validator, it will always fail to find a certificate for the validation.

To restore the previous functionality of the spring-xsuaa module, which is in maintenance mode, I am explicitly importing only the previous default validator(s) instead which happens to be only a timestamp validator.