### PR TITLE
fix: reduce log level to debug for certificate parsing

### DIFF
--- a/java-security/src/main/java/com/sap/cloud/security/x509/X509Certificate.java
+++ b/java-security/src/main/java/com/sap/cloud/security/x509/X509Certificate.java
@@ -46,7 +46,7 @@ public class X509Certificate implements Certificate {
 			try {
 				return new X509Certificate(X509Parser.parseCertificate(pem), pem);
 			} catch (CertificateException e) {
-				LOGGER.warn("Could not parse the certificate string", e);
+				LOGGER.debug("Could not parse the certificate string", e);
 			}
 		}
 		return null;


### PR DESCRIPTION
In presence of a XFCC header containing no PEM-formatted certificate, the client library logged a warning for each incoming request. For Istio enabled applications which use a different format for this header, this resulted in log pollution. Since the certificate is only used by the library for x5t and proof token validation, the log level is reduced to debug. A missing certificate anyway leads to an error later on.