### PR TITLE
When parsing PEM files, consider CRLF (in addition to LF)

### DIFF
--- a/token-client/src/main/java/com/sap/cloud/security/mtls/SSLContextFactory.java
+++ b/token-client/src/main/java/com/sap/cloud/security/mtls/SSLContextFactory.java
@@ -52,7 +52,9 @@ public class SSLContextFactory {
 				.replace("-----END RSA PRIVATE KEY-----", "")
 				.replace("-----END PRIVATE KEY-----", "")
 				.replace("\\n", "")
-				.replace("\n", "");
+				.replace("\n", "")
+				.replace("\\r", "")
+				.replace("\r", "");
 	}
 
 	/**


### PR DESCRIPTION
[In our project](https://github.com/SAP/cloud-sdk-java) we noticed Windows users unable to run certain tests.
In many default installations of Git, the line-ending CRLF (`\r\n`) will be used when checking out text based files.

We found exceptions like the following (for `3.5.3`):
```
java.lang.IllegalArgumentException: Illegal base64 character d
	at java.base/java.util.Base64$Decoder.decode0(Base64.java:852)
	at java.base/java.util.Base64$Decoder.decode(Base64.java:570)
	at java.base/java.util.Base64$Decoder.decode(Base64.java:593)
	at com.sap.cloud.security.mtls.SSLContextFactory.getPrivateKey(SSLContextFactory.java:157)
	at com.sap.cloud.security.mtls.SSLContextFactory.createKeyStore(SSLContextFactory.java:144)
	at com.sap.cloud.sdk.cloudplatform.connectivity.BtpServicePropertySuppliers$IdentityAuthentication.getClientKeyStore(BtpServicePropertySuppliers.java:277)
	... 55 more
```

Maybe we can support Windows users as well? :)

(Code quality could be improved by combined regex.)