### PR TITLE
Set release version to 3.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,33 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 3.5.5
+
+- [token-client] Support CRLF line-endings in PEM formatted service keys
+
+### Dependency upgrades
+
+- Bump org.apache.httpcomponents.client5:httpclient5 from 5.3.1 to 5.4.1
+- Bump io.projectreactor:reactor-test from 3.6.9 to 3.7.0
+- Update spring versions
+  - core to 6.2.0
+  - boot to 3.4.0
+  - security to 6.4.1
+- Bump org.wiremock:wiremock-standalone from 3.9.1 to 3.9.2
+- Bump uk.org.webcompere:system-stubs-jupiter from 2.1.6 to 2.1.7
+- Bump com.nimbusds:nimbus-jose-jwt from 9.40 to 9.47
+- Bump com.sap.cloud.environment.servicebinding:java-bom from 0.10.5 to 0.20.0
+- Bump log4j2.version from 2.24.1 to 2.24.2
+- Bump org.apache.maven.plugins:maven-pmd-plugin from 3.24.0 to 3.26.0
+- Bump org.apache.maven.plugins:maven-source-plugin from 3.2.1 to 3.3.1
+- Bump net.revelc.code:impsort-maven-plugin from 1.11.0 to 1.12.0
+- Bump org.owasp:dependency-check-maven from 10.0.3 to 11.1.0
+- Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.5 to 3.2.7
+- Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.8.0 to 3.11.1
+- Bump org.apache.maven.plugins:maven-surefire-plugin from 3.4.0 to 3.5.2
+- Bump com.github.spotbugs:spotbugs-maven-plugin from 4.8.6.2 to 4.8.6.6
+- Bump commons-io:commons-io from 2.16.1 to 2.18.0
+
 ## 3.5.4
 
 - [java-security] Reduce log level to debug for errors during certificate parsing

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The SAP Cloud Security Services Integration is published to maven central: https
         <dependency>
             <groupId>com.sap.cloud.security</groupId>
             <artifactId>java-bom</artifactId>
-            <version>3.5.4</version>
+            <version>3.5.5</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-bom</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
     <packaging>pom</packaging>
     <name>java-bom</name>
 

--- a/env/pom.xml
+++ b/env/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
         <artifactId>parent</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
     </parent>
 
     <groupId>com.sap.cloud.security</groupId>

--- a/java-api/README.md
+++ b/java-api/README.md
@@ -5,6 +5,6 @@
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-api</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
 </dependency>
 ```

--- a/java-api/pom.xml
+++ b/java-api/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security-it/pom.xml
+++ b/java-security-it/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
     </parent>
 
     <artifactId>java-security-it</artifactId>

--- a/java-security-test/README.md
+++ b/java-security-test/README.md
@@ -40,7 +40,7 @@ It is pre-configured with a security filter that only accepts valid tokens. Furt
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
    <artifactId>java-security-test</artifactId>
-   <version>3.5.4</version>
+   <version>3.5.5</version>
    <scope>test</scope>
 </dependency>
 ```

--- a/java-security-test/pom.xml
+++ b/java-security-test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security/README.md
+++ b/java-security/README.md
@@ -67,7 +67,7 @@ To be able to validate tokens it performs the following tasks:
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-security</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/java-security/pom.xml
+++ b/java-security/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>com.sap.cloud.security.xsuaa</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.5.4</version>
+	<version>3.5.5</version>
 	<packaging>pom</packaging>
 
 	<name>parent</name>

--- a/samples/java-security-usage-ias/pom.xml
+++ b/samples/java-security-usage-ias/pom.xml
@@ -6,13 +6,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-security-usage-ias</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
     <packaging>war</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <sap.cloud.security.version>3.5.4</sap.cloud.security.version>
+        <sap.cloud.security.version>3.5.5</sap.cloud.security.version>
         <slf4j.api.version>2.0.5</slf4j.api.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>

--- a/samples/java-security-usage/pom.xml
+++ b/samples/java-security-usage/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-security-usage</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
     <packaging>war</packaging>
 
     <!--profiles>
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <sap.cloud.security.version>3.5.4</sap.cloud.security.version>
+        <sap.cloud.security.version>3.5.5</sap.cloud.security.version>
         <slf4j.api.version>2.0.5</slf4j.api.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>

--- a/samples/java-tokenclient-usage/pom.xml
+++ b/samples/java-tokenclient-usage/pom.xml
@@ -6,13 +6,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-tokenclient-usage</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
     <packaging>war</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <sap.cloud.security.version>3.5.4</sap.cloud.security.version>
+        <sap.cloud.security.version>3.5.5</sap.cloud.security.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>
         <slf4j.api.version>2.0.5</slf4j.api.version>

--- a/samples/sap-java-buildpack-api-usage/pom.xml
+++ b/samples/sap-java-buildpack-api-usage/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.sap.cloud.security.xssec.samples</groupId>
 	<artifactId>sap-java-buildpack-api-usage</artifactId>
-	<version>3.5.4</version>
+	<version>3.5.5</version>
 	<packaging>war</packaging>
 
 	<properties>

--- a/samples/spring-security-basic-auth/pom.xml
+++ b/samples/spring-security-basic-auth/pom.xml
@@ -13,14 +13,14 @@
 	</parent>
 
 	<artifactId>spring-security-basic-auth</artifactId>
-	<version>3.5.4</version>
+	<version>3.5.5</version>
 	<name>spring-security-basic-auth</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<sap.cloud.security.version>3.5.4</sap.cloud.security.version>
+		<sap.cloud.security.version>3.5.5</sap.cloud.security.version>
 	</properties>
 
 	<dependencyManagement>
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>com.sap.cloud.security</groupId>
 			<artifactId>java-security-test</artifactId>
-			<version>3.5.4</version>
+			<version>3.5.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/samples/spring-security-hybrid-usage/pom.xml
+++ b/samples/spring-security-hybrid-usage/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.sap.cloud.security.samples</groupId>
 	<artifactId>spring-security-hybrid-usage</artifactId>
-	<version>3.5.4</version>
+	<version>3.5.5</version>
 
 	<properties>
 		<!-- 
@@ -28,7 +28,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<sap.cloud.security.version>3.5.4</sap.cloud.security.version>
+		<sap.cloud.security.version>3.5.5</sap.cloud.security.version>
 		<apache.httpclient.version>4.5.14</apache.httpclient.version>
 	</properties>
 

--- a/samples/spring-security-xsuaa-usage/pom.xml
+++ b/samples/spring-security-xsuaa-usage/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.sap.cloud.security.samples</groupId>
 	<artifactId>spring-security-xsuaa-usage</artifactId>
-	<version>3.5.4</version>
+	<version>3.5.5</version>
 	<name>spring-security-xsuaa-usage</name>
 
 	<properties>
@@ -29,7 +29,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<sap.cloud.security.version>3.5.4</sap.cloud.security.version>
+		<sap.cloud.security.version>3.5.5</sap.cloud.security.version>
 		<http.client5>5.2.1</http.client5>
 	</properties>
 

--- a/samples/spring-webflux-security-hybrid-usage/pom.xml
+++ b/samples/spring-webflux-security-hybrid-usage/pom.xml
@@ -14,12 +14,12 @@
 
     <groupId>com.sap.cloud.security.samples</groupId>
     <artifactId>spring-webflux-security-hybrid-usage</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
     <name>spring-webflux-security-hybrid-usage</name>
 
     <properties>
         <java.version>17</java.version>
-        <sap.cloud.security.version>3.5.4</sap.cloud.security.version>
+        <sap.cloud.security.version>3.5.5</sap.cloud.security.version>
     </properties>
 
     <dependencyManagement>

--- a/spring-security-compatibility/pom.xml
+++ b/spring-security-compatibility/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
         <artifactId>parent</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
     </parent>
 
     <groupId>com.sap.cloud.security.xsuaa</groupId>

--- a/spring-security-starter/pom.xml
+++ b/spring-security-starter/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/spring-security/Migration_SpringXsuaaProjects.md
+++ b/spring-security/Migration_SpringXsuaaProjects.md
@@ -157,7 +157,7 @@ It is provided in an extra module. This maven dependency needs to be provided ad
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-security-compatibility</artifactId>
-  <version>3.5.4</version>
+  <version>3.5.5</version>
 </dependency>
 ```
 

--- a/spring-security/README.md
+++ b/spring-security/README.md
@@ -67,7 +67,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-starter</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
 </dependency>
 ```
 

--- a/spring-security/pom.xml
+++ b/spring-security/pom.xml
@@ -9,13 +9,13 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>
 	<artifactId>spring-security</artifactId>
 	<packaging>jar</packaging>
-	<version>3.5.4</version>
+	<version>3.5.5</version>
 
 	<dependencies>
 <!--		TODO remove once spring-security-oauth2-jose has a newer version with updated nimbus dependency-->

--- a/spring-xsuaa-it/pom.xml
+++ b/spring-xsuaa-it/pom.xml
@@ -14,12 +14,12 @@
 
 	<artifactId>spring-xsuaa-it</artifactId>
 	<name>spring-xsuaa-it</name>
-	<version>3.5.4</version>
+	<version>3.5.5</version>
 
 	<properties>
 		<mockwebserver.version>4.10.0</mockwebserver.version>
 		<java.version>17</java.version>
-		<sap.cloud.security.version>3.5.4</sap.cloud.security.version>
+		<sap.cloud.security.version>3.5.5</sap.cloud.security.version>
 	</properties>
 
 	<dependencyManagement>

--- a/spring-xsuaa-starter/pom.xml
+++ b/spring-xsuaa-starter/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5</version>
 	</parent>
 
 	<artifactId>xsuaa-spring-boot-starter</artifactId>

--- a/spring-xsuaa-test/README.md
+++ b/spring-xsuaa-test/README.md
@@ -31,7 +31,7 @@ This includes for example a `JwtGenerator` that generates JSON Web Tokens (JWT) 
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-xsuaa-test</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
     <scope>test</scope>
 </dependency>
 

--- a/spring-xsuaa-test/pom.xml
+++ b/spring-xsuaa-test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5</version>
 	</parent>
 
 	<artifactId>spring-xsuaa-test</artifactId>

--- a/spring-xsuaa/README.md
+++ b/spring-xsuaa/README.md
@@ -39,7 +39,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-xsuaa</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
 </dependency>
 <dependency> <!-- new with version 1.5.0 -->
     <groupId>org.apache.logging.log4j</groupId>
@@ -53,7 +53,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>xsuaa-spring-boot-starter</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
 </dependency>
 ```
 

--- a/spring-xsuaa/pom.xml
+++ b/spring-xsuaa/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5</version>
 	</parent>
 
 	<artifactId>spring-xsuaa</artifactId>

--- a/token-client/README.md
+++ b/token-client/README.md
@@ -49,7 +49,7 @@ In context of a Spring Boot application you can leverage autoconfiguration provi
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-starter</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
 </dependency>
 ```
 In context of Spring Applications you will need the following dependencies:
@@ -57,7 +57,7 @@ In context of Spring Applications you will need the following dependencies:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>
@@ -124,7 +124,7 @@ See the [OAuth2ServiceConfiguration](#oauth2serviceconfiguration) section and [H
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client</artifactId>
-    <version>3.5.4</version>
+    <version>3.5.5</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/token-client/pom.xml
+++ b/token-client/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5</version>
 	</parent>
 
 	<artifactId>token-client</artifactId>


### PR DESCRIPTION
Release 3.5.5:
- [token-client] Support CRLF line-endings in PEM formatted service keys

Dependency upgrades:
- Bump org.apache.httpcomponents.client5:httpclient5 from 5.3.1 to 5.4.1
- Bump io.projectreactor:reactor-test from 3.6.9 to 3.7.0
- Update spring versions
  - core to 6.2.0
  - boot to 3.4.0
  - security to 6.4.1
- Bump org.wiremock:wiremock-standalone from 3.9.1 to 3.9.2
- Bump uk.org.webcompere:system-stubs-jupiter from 2.1.6 to 2.1.7
- Bump com.nimbusds:nimbus-jose-jwt from 9.40 to 9.47
- Bump com.sap.cloud.environment.servicebinding:java-bom from 0.10.5 to 0.20.0
- Bump log4j2.version from 2.24.1 to 2.24.2
- Bump org.apache.maven.plugins:maven-pmd-plugin from 3.24.0 to 3.26.0
- Bump org.apache.maven.plugins:maven-source-plugin from 3.2.1 to 3.3.1
- Bump net.revelc.code:impsort-maven-plugin from 1.11.0 to 1.12.0
- Bump org.owasp:dependency-check-maven from 10.0.3 to 11.1.0
- Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.5 to 3.2.7
- Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.8.0 to 3.11.1
- Bump org.apache.maven.plugins:maven-surefire-plugin from 3.4.0 to 3.5.2
- Bump com.github.spotbugs:spotbugs-maven-plugin from 4.8.6.2 to 4.8.6.6
- Bump commons-io:commons-io from 2.16.1 to 2.18.0
