### PR TITLE
revert jetty to 12.0.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 		<spring.security.version>6.3.4</spring.security.version>
 		<spring.security.oauth2.version>2.5.2.RELEASE</spring.security.oauth2.version>
 		<spring.security.jwt.version>1.1.1.RELEASE</spring.security.jwt.version>
-		<org.eclipse.jetty.version>12.0.14</org.eclipse.jetty.version>
+		<org.eclipse.jetty.version>12.0.13</org.eclipse.jetty.version>
 		<reactor.version>3.6.9</reactor.version>
 		<log4j2.version>2.24.1</log4j2.version>
 		<slf4j.api.version>2.0.16</slf4j.api.version> <!--see also here http://www.slf4j.org/faq.html#changesInVersion18 -->


### PR DESCRIPTION
due to dependency issues with jetty-server referencing an incompatible jetty-util we revert the latest version update for now