### PR TITLE
Remove dependency-check-maven plugin from build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,26 +383,6 @@
 							</executions>
 						</plugin>
 						<plugin>
-							<groupId>org.owasp</groupId> <!--scans for vulnerabilities-->
-							<artifactId>dependency-check-maven</artifactId>
-							<version>11.1.0</version>
-							<executions>
-								<execution>
-									<goals>
-										<goal>check</goal>
-									</goals>
-								</execution>
-							</executions>
-							<configuration>
-								<skip>${skipTests}</skip>
-								<skipProvidedScope>true</skipProvidedScope>
-								<failBuildOnCVSS>7</failBuildOnCVSS>
-								<suppressionFile>${project.basedir}/../etc/suppression.xml</suppressionFile>
-								<nvdValidForHours>24</nvdValidForHours>
-								<nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
-							</configuration>
-						</plugin>
-						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-javadoc-plugin</artifactId>
 							<version>3.11.1</version>


### PR DESCRIPTION
Dependency check is done by dependabot already and does not need to be done in the build. Furthermore, the build was unstable because of connection issues while downloading vulnerability data from NVD. Instead of investing into stabilizing the NVD based dependency check (e.g. by caching the NVD data), the decision was to replace it with a dependabot only approach.

As a consequence, during the release of a new library version, we need to double check for any waiting dependabot PRs that might fix a known vulnerability.