### PR TITLE
Reactor fix and wiremock downgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
 		<hamcrest.version>1.3</hamcrest.version>
 		<mockito.version>5.15.2</mockito.version>
 		<assertj.version>3.27.3</assertj.version>
-		<wiremock.version>3.10.0</wiremock.version>
 		<reactor.test.version>3.7.2</reactor.test.version>
+		<wiremock.version>3.9.2</wiremock.version>
 		<javax.annotation.version>1.3.2</javax.annotation.version>
 		<spotbugs.annotations.version>4.8.6</spotbugs.annotations.version>
 		<spotbugs.version>4.8.6.6</spotbugs.version>


### PR DESCRIPTION
This PR brings two changes:
1. fix for reactive token validation error handling
2. downgrade of wiremock-standalone (to mitigate test issues)