### PR TITLE
SCICAS-3386 Extend token validation results with retryability flag

### DIFF
--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/ValidationResult.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/ValidationResult.java
@@ -31,6 +31,15 @@ public interface ValidationResult {
 	}
 
 	/**
+	 * Returns true if there is a validation error which might be resolved by retrying the validation.
+	 *
+	 * @return true if there is a retryable validation error.
+	 */
+	default boolean isRetryable() {
+		return false;
+	}
+
+	/**
 	 * The validation error that have been found.
 	 *
 	 * @return the error description or null in case the validation was valid.

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/ValidationResults.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/ValidationResults.java
@@ -59,6 +59,32 @@ public class ValidationResults {
 	}
 
 	/**
+	 * Creates a retryable {@link ValidationResult} that contains an error description.
+	 *
+	 * @param errorDescription
+	 * 		the error description.
+	 * @return a retryable {@link ValidationResult} containing an error description.
+	 */
+	public static ValidationResult createRetryableError(String errorDescription) {
+		logger.warn(errorDescription);
+		return new ValidationResultImpl(errorDescription, true);
+	}
+
+	/**
+	 * Same as {@link #createInvalid(String, Object...)} but creates a retryable error.
+	 *
+	 * @param errorDescriptionTemplate
+	 * 		the description as template used to create the error description.
+	 * @param arguments
+	 * 		the arguments that are filled inside the description template.
+	 * @return a retryable {@link ValidationResult} containing one error description.
+	 */
+	public static ValidationResult createRetryableError(String errorDescriptionTemplate, Object... arguments) {
+		String format = MessageFormatter.arrayFormat(errorDescriptionTemplate, arguments).getMessage();
+		return createRetryableError(format);
+	}
+
+	/**
 	 * Creates a valid {@link ValidationResult}, which is a {@link ValidationResult} that contains no errors.
 	 *
 	 * @return a valid validation result.
@@ -70,9 +96,15 @@ public class ValidationResults {
 	static class ValidationResultImpl implements ValidationResult {
 
 		private final String validationError;
+		private final boolean retryableError;
+
+		public ValidationResultImpl(String validationError, boolean retryableError) {
+			this.validationError = validationError;
+			this.retryableError = retryableError;
+		}
 
 		public ValidationResultImpl(String validationError) {
-			this.validationError = validationError;
+			this(validationError, false);
 		}
 
 		public ValidationResultImpl() {
@@ -83,6 +115,11 @@ public class ValidationResults {
 		@Override
 		public String getErrorDescription() {
 			return validationError;
+		}
+
+		@Override
+		public boolean isRetryable() {
+			return retryableError;
 		}
 
 		@Override

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtSignatureValidator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtSignatureValidator.java
@@ -18,6 +18,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.util.Base64;
 
 import static com.sap.cloud.security.token.validation.ValidationResults.createInvalid;
+import static com.sap.cloud.security.token.validation.ValidationResults.createRetryableError;
 import static com.sap.cloud.security.token.validation.ValidationResults.createValid;
 import static com.sap.cloud.security.token.validation.validators.JsonWebKeyConstants.ALG_PARAMETER_NAME;
 import static com.sap.cloud.security.xsuaa.Assertions.assertNotNull;
@@ -64,7 +65,7 @@ abstract class JwtSignatureValidator implements Validator<Token> {
 		try {
 			publicKey = getPublicKey(token, algorithm);
 		} catch (OAuth2ServiceException e) {
-			return createInvalid("Token signature can not be validated because JWKS could not be fetched: {}",
+			return createRetryableError("Token signature can not be validated because JWKS could not be fetched: {}",
 					e.getMessage());
 		} catch (IllegalArgumentException | InvalidKeySpecException | NoSuchAlgorithmException e) {
 			return createInvalid("Token signature can not be validated because: {}", e.getMessage());

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtSignatureValidator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtSignatureValidator.java
@@ -65,8 +65,12 @@ abstract class JwtSignatureValidator implements Validator<Token> {
 		try {
 			publicKey = getPublicKey(token, algorithm);
 		} catch (OAuth2ServiceException e) {
-			return createRetryableError("Token signature can not be validated because JWKS could not be fetched: {}",
-					e.getMessage());
+			String errorDescriptionTemplate = "Token signature can not be validated because JWKS could not be fetched: {}";
+			if (e.isRetryable()) {
+				return createRetryableError(errorDescriptionTemplate, e.getMessage());
+			} else {
+				return createInvalid(errorDescriptionTemplate, e.getMessage());
+			}
 		} catch (IllegalArgumentException | InvalidKeySpecException | NoSuchAlgorithmException e) {
 			return createInvalid("Token signature can not be validated because: {}", e.getMessage());
 		}

--- a/spring-security/src/main/java/com/sap/cloud/security/spring/token/authentication/HybridJwtDecoder.java
+++ b/spring-security/src/main/java/com/sap/cloud/security/spring/token/authentication/HybridJwtDecoder.java
@@ -82,12 +82,11 @@ public class HybridJwtDecoder implements JwtDecoder {
 		case XSUAA -> validationResult = xsuaaTokenValidators.validate(token);
 		default -> throw new BadJwtException("Tokens issued by " + token.getService() + " service aren't supported.");
 		}
+		if (validationResult.isRetryable()) {
+			throw new JwtException(validationResult.getErrorDescription());
+		}
 		if (validationResult.isErroneous()) {
-			if (validationResult.getErrorDescription().contains("JWKS could not be fetched")) {
-				throw new JwtException(validationResult.getErrorDescription());
-			} else {
-				throw new BadJwtException("The token is invalid: " + validationResult.getErrorDescription());
-			}
+			throw new BadJwtException("The token is invalid: " + validationResult.getErrorDescription());
 		}
 		logger.debug("Token issued by {} service was successfully validated.", token.getService());
 		return jwt;

--- a/spring-security/src/main/java/com/sap/cloud/security/spring/token/authentication/IasJwtDecoder.java
+++ b/spring-security/src/main/java/com/sap/cloud/security/spring/token/authentication/IasJwtDecoder.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.jwt.BadJwtException;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
 import org.springframework.util.Assert;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -58,6 +59,9 @@ public class IasJwtDecoder implements JwtDecoder {
 			Assert.hasText(encodedToken, "encodedToken must neither be null nor empty String.");
 			Token token = Token.create(encodedToken);
 			ValidationResult validationResult = tokenValidators.validate(token);
+			if (validationResult.isRetryable()) {
+				throw new JwtException(validationResult.getErrorDescription());
+			}
 			if (validationResult.isErroneous()) {
 				throw new InvalidBearerTokenException("The token is invalid.");
 			}

--- a/spring-security/src/main/java/com/sap/cloud/security/spring/token/authentication/ReactiveHybridJwtDecoder.java
+++ b/spring-security/src/main/java/com/sap/cloud/security/spring/token/authentication/ReactiveHybridJwtDecoder.java
@@ -51,6 +51,9 @@ public class ReactiveHybridJwtDecoder implements ReactiveJwtDecoder {
 						return Mono.error(new BadJwtException(
 								"Tokens issued by " + token.getService() + " service aren´t supported."));
 					}
+					if (validationResult.isRetryable()) {
+						return Mono.error(new JwtException(validationResult.getErrorDescription()));
+					}
 					if (validationResult.isErroneous()) {
 						return Mono.error(new BadJwtException(
 								"The token is invalid: " + validationResult.getErrorDescription()));

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2ServiceException.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2ServiceException.java
@@ -59,6 +59,25 @@ public class OAuth2ServiceException extends IOException {
 	}
 
 	/**
+	 * Determines if the HTTP request that resulted in this exception is retryable.
+	 * <p>
+	 * A request is considered retryable if the HTTP status code is one of the following:
+	 * <ul>
+	 *   <li>null, 0 - No response (or service wasn't called auccessfully, e.g. due to an IOException)</li>
+	 *   <li>408 - Request Timeout</li>
+	 *   <li>429 - Too Many Requests</li>
+	 *   <li>5xx - Any server error status code (500-599)</li>
+	 * </ul>
+	 *
+	 * @return {@code true} if the request is retryable, {@code false} otherwise
+	 */	public boolean isRetryable() {
+		return httpStatusCode == null || httpStatusCode == 0
+				|| httpStatusCode == 408
+				|| httpStatusCode == 429
+				|| (httpStatusCode >= 500 && httpStatusCode < 600);
+	}
+
+	/**
 	 * Returns the HTTP status code of the failed OAuth2 service request or {@code 0} e.g. in case the service wasn't
 	 * called at all.
 	 *

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2ServiceException.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2ServiceException.java
@@ -63,7 +63,7 @@ public class OAuth2ServiceException extends IOException {
 	 * <p>
 	 * A request is considered retryable if the HTTP status code is one of the following:
 	 * <ul>
-	 *   <li>null, 0 - No response (or service wasn't called auccessfully, e.g. due to an IOException)</li>
+	 *   <li>null, 0 - No response (or service wasn't called successfully, e.g. due to an IOException)</li>
 	 *   <li>408 - Request Timeout</li>
 	 *   <li>429 - Too Many Requests</li>
 	 *   <li>5xx - Any server error status code (500-599)</li>


### PR DESCRIPTION
Validation results can now be flagged as retryable which is used to mark error while fetching JWKS. This allows clients to retry the validation when it may only have failed due to temporary network hickups while contacting the IAS tenant.

Jira: SCICAS-3386