### PR TITLE
fix null value (and key) support in configuration builder

### DIFF
--- a/env/src/main/java/com/sap/cloud/security/config/OAuth2ServiceConfigurationBuilder.java
+++ b/env/src/main/java/com/sap/cloud/security/config/OAuth2ServiceConfigurationBuilder.java
@@ -195,7 +195,7 @@ public class OAuth2ServiceConfigurationBuilder {
 	 * @return the oauth2 service configuration.
 	 */
 	public OAuth2ServiceConfiguration build() {
-		return new OAuth2ServiceConfigurationImpl(Map.copyOf(properties), service, List.copyOf(domains), runInLegacyMode);
+		return new OAuth2ServiceConfigurationImpl(new HashMap<>(properties), service, new ArrayList<>(domains), runInLegacyMode);
 	}
 
 	private static class OAuth2ServiceConfigurationImpl implements OAuth2ServiceConfiguration {

--- a/env/src/test/java/com/sap/cloud/security/config/OAuth2ServiceConfigurationBuilderTest.java
+++ b/env/src/test/java/com/sap/cloud/security/config/OAuth2ServiceConfigurationBuilderTest.java
@@ -132,6 +132,26 @@ public class OAuth2ServiceConfigurationBuilderTest {
 	}
 
 	@Test
+	public void withPropertyKeyIsNull() {
+		String propertyName = null;
+		String propertyValue = "value";
+
+		OAuth2ServiceConfiguration configuration = cut.withProperty(propertyName, propertyValue).build();
+
+		assertThat(configuration.getProperty(propertyName)).isEqualTo(propertyValue);
+	}
+
+	@Test
+	public void withPropertyValueIsNull() {
+		String propertyName = "propertyName";
+		String propertyValue = null;
+
+		OAuth2ServiceConfiguration configuration = cut.withProperty(propertyName, propertyValue).build();
+
+		assertThat(configuration.getProperty(propertyName)).isEqualTo(propertyValue);
+	}
+
+	@Test
 	public void withUrl_setViaProperty() {
 		String url = "http://theUrl.org";
 


### PR DESCRIPTION
A recent fix of the oauth configuration builder based on Map.copy for copying the properties of an configuration object broke consumers having null values (or keys) in the properties map of the configuration.

This change swaps tha call to Map.copy() with calling the constructor of HashMap which supports null. Same is done for copying the list of domains.

Fixes #1743