### PR TITLE
NGPBUG-429025 fix error logging during token key retrieval

### DIFF
--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidator.java
@@ -10,7 +10,6 @@ import com.sap.cloud.security.xsuaa.client.DefaultOidcConfigurationService;
 import com.sap.cloud.security.xsuaa.client.OAuth2ServiceEndpointsProvider;
 import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
 import com.sap.cloud.security.xsuaa.http.HttpHeaders;
-import org.springframework.util.StringUtils;
 
 import javax.annotation.Nonnull;
 import java.net.URI;

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidator.java
@@ -10,6 +10,7 @@ import com.sap.cloud.security.xsuaa.client.DefaultOidcConfigurationService;
 import com.sap.cloud.security.xsuaa.client.OAuth2ServiceEndpointsProvider;
 import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
 import com.sap.cloud.security.xsuaa.http.HttpHeaders;
+import org.springframework.util.StringUtils;
 
 import javax.annotation.Nonnull;
 import java.net.URI;
@@ -122,6 +123,9 @@ class SapIdJwtSignatureValidator extends JwtSignatureValidator {
 	@Nonnull
 	private URI getOidcJwksUri(String domain) throws OAuth2ServiceException {
 		URI discoveryUri = DefaultOidcConfigurationService.getDiscoveryEndpointUri(domain);
+		if (discoveryUri == null) {
+			throw new IllegalArgumentException("OIDC .well-known discovery URI could not be constructed.");
+		}
 
 		OAuth2ServiceEndpointsProvider endpointsProvider = oidcConfigurationService
 				.getOrRetrieveEndpoints(discoveryUri);

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/XsuaaJwtSignatureValidator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/XsuaaJwtSignatureValidator.java
@@ -59,27 +59,24 @@ class XsuaaJwtSignatureValidator extends JwtSignatureValidator {
 			key = fetchPublicKey(token, algorithm);
 		} catch (OAuth2ServiceException | InvalidKeySpecException | NoSuchAlgorithmException
 				| IllegalArgumentException e) {
-			LOGGER.error("Error fetching public key from XSUAA service: {}", e.getMessage());
 			if (!configuration.hasProperty(ServiceConstants.XSUAA.VERIFICATION_KEY)) {
+				LOGGER.error("Error fetching public key from XSUAA service: {}", e.getMessage());
 				throw e;
 			}
 
-			if (configuration.hasProperty(ServiceConstants.XSUAA.VERIFICATION_KEY)) {
-				String fallbackKey = configuration.getProperty(ServiceConstants.XSUAA.VERIFICATION_KEY);
-				try {
-					key = JsonWebKeyImpl.createPublicKeyFromPemEncodedPublicKey(JwtSignatureAlgorithm.RS256,
-							fallbackKey);
-				} catch (NoSuchAlgorithmException | InvalidKeySpecException ex) {
-					IllegalArgumentException illegalArgEx = new IllegalArgumentException(
-							"Fallback validation key supplied via " + ServiceConstants.XSUAA.VERIFICATION_KEY
-									+ " property in service credentials could not be used: " + ex.getMessage());
-					if (e instanceof OAuth2ServiceException) {
-						e.addSuppressed(illegalArgEx);
-						throw e;
-					}
-					throw illegalArgEx;
-
+			String fallbackKey = configuration.getProperty(ServiceConstants.XSUAA.VERIFICATION_KEY);
+			try {
+				key = JsonWebKeyImpl.createPublicKeyFromPemEncodedPublicKey(JwtSignatureAlgorithm.RS256,
+						fallbackKey);
+			} catch (NoSuchAlgorithmException | InvalidKeySpecException ex) {
+				IllegalArgumentException illegalArgEx = new IllegalArgumentException(
+						"Fallback validation key supplied via " + ServiceConstants.XSUAA.VERIFICATION_KEY
+								+ " property in service credentials could not be used: " + ex.getMessage());
+				if (e instanceof OAuth2ServiceException) {
+					e.addSuppressed(illegalArgEx);
+					throw e;
 				}
+				throw illegalArgEx;
 			}
 		}
 

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultOidcConfigurationService.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultOidcConfigurationService.java
@@ -38,12 +38,18 @@ public class DefaultOidcConfigurationService implements OidcConfigurationService
 		this.httpClient = httpClient;
 	}
 
-	public static URI getDiscoveryEndpointUri(@Nonnull String issuerUri) {
-		// to support existing IAS applications
-		URI uri = URI.create(issuerUri.startsWith("http://localhost") || issuerUri.startsWith("https://") ? issuerUri
-				: "https://" + issuerUri);
-		return UriUtil.expandPath(uri, DISCOVERY_ENDPOINT_DEFAULT);
+public static URI getDiscoveryEndpointUri(@Nonnull String issuerUri) {
+	URI uri;
+	if (issuerUri.startsWith("http://localhost") || issuerUri.startsWith("https://")) {
+		uri = URI.create(issuerUri);
+	} else if (issuerUri.startsWith("http://")) {
+		// non-localhost http discovery endpoints are not supported
+		return null;
+	} else {
+		uri = URI.create("https://" + issuerUri);
 	}
+	return UriUtil.expandPath(uri, DISCOVERY_ENDPOINT_DEFAULT);
+}
 
 	@Override
 	public OAuth2ServiceEndpointsProvider retrieveEndpoints(@Nonnull URI discoveryEndpointUri)


### PR DESCRIPTION
Do not log an error during token key retrieval when a fallback is available.

Also: Improve error handling for OIDC discovery URL construction.

Bug: NGPBUG-429025