### PR TITLE
NGPBUG-432478 auto-convert token claims to string

### DIFF
--- a/env/src/main/java/com/sap/cloud/security/json/DefaultJsonObject.java
+++ b/env/src/main/java/com/sap/cloud/security/json/DefaultJsonObject.java
@@ -81,6 +81,15 @@ public class DefaultJsonObject implements JsonObject {
 		return null;
 	}
 
+	@Nullable
+	public String getAsOptString(String name) {
+		try {
+			return Optional.ofNullable(getJsonObject().opt(name)).map(Object::toString).orElse(null);
+		} catch (JSONException e) {
+			throw new JsonParsingException(e.getMessage());
+		}
+	}
+
 	@Override
 	@Nullable
 	public Instant getAsInstant(String name) {

--- a/env/src/test/java/com/sap/cloud/security/json/DefaultJsonObjectTest.java
+++ b/env/src/test/java/com/sap/cloud/security/json/DefaultJsonObjectTest.java
@@ -27,7 +27,7 @@ public class DefaultJsonObjectTest {
 	private static final String STRING_TEXT = "string text";
 	private static final String STRING_VALUE = "\"" + STRING_TEXT + "\"";
 
-	private static final String STRING_LIST_VALUE = "[\"a\", \"b\", \"c\"]";
+	private static final String STRING_LIST_VALUE = "[\"a\",\"b\",\"c\"]";
 
 	private DefaultJsonObject cut;
 
@@ -72,6 +72,18 @@ public class DefaultJsonObjectTest {
 		cut = createJsonParser(KEY_2, STRING_LIST_VALUE);
 
 		assertThatThrownBy(() -> cut.getAsString(KEY_2)).isInstanceOf(JsonParsingException.class);
+	}
+
+	@Test
+	public void getAsOptString_keyDoesNotExists_returnsNull() {
+		assertThat(cut.getAsOptString("keyDoesNotExist")).isNull();
+	}
+
+	@Test
+	public void getAsOptString_keyDoesExistButTypeIsWrong_triggersConversion() {
+		cut = createJsonParser(KEY_2, STRING_LIST_VALUE);
+
+		assertThat(cut.getAsOptString(KEY_2)).isEqualTo(STRING_LIST_VALUE);
 	}
 
 	@Test

--- a/java-security/src/main/java/com/sap/cloud/security/token/AbstractToken.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/AbstractToken.java
@@ -74,7 +74,7 @@ public abstract class AbstractToken implements Token {
 	@Nullable
 	@Override
 	public String getClaimAsString(@Nonnull String claimName) {
-		return tokenBody.getAsString(claimName);
+		return tokenBody.getAsOptString(claimName);
 	}
 
 	@Nonnull


### PR DESCRIPTION
If token claims are retrieved via getClaimAsString(), then values of non-string type will now be converted using Object::toString().