### PR TITLE
SCICAS-3386 Fix spring retry configuration for token service

### DIFF
--- a/spring-security/src/main/java/com/sap/cloud/security/spring/autoconfig/XsuaaTokenFlowAutoConfiguration.java
+++ b/spring-security/src/main/java/com/sap/cloud/security/spring/autoconfig/XsuaaTokenFlowAutoConfiguration.java
@@ -6,6 +6,7 @@
 package com.sap.cloud.security.spring.autoconfig;
 
 import com.sap.cloud.security.client.HttpClientFactory;
+import com.sap.cloud.security.client.SpringTokenClientConfiguration;
 import com.sap.cloud.security.config.ClientIdentity;
 import com.sap.cloud.security.spring.config.XsuaaServiceConfiguration;
 import com.sap.cloud.security.spring.config.XsuaaServiceConfigurations;
@@ -13,6 +14,7 @@ import com.sap.cloud.security.xsuaa.client.DefaultOAuth2TokenService;
 import com.sap.cloud.security.xsuaa.client.OAuth2ServiceEndpointsProvider;
 import com.sap.cloud.security.xsuaa.client.OAuth2TokenService;
 import com.sap.cloud.security.xsuaa.client.XsuaaDefaultEndpoints;
+import com.sap.cloud.security.xsuaa.tokenflows.TokenCacheConfiguration;
 import com.sap.cloud.security.xsuaa.tokenflows.XsuaaTokenFlows;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.slf4j.Logger;
@@ -61,7 +63,9 @@ public class XsuaaTokenFlowAutoConfiguration {
 				xsuaaConfig.getClientIdentity().isCertificateBased() ? "certificate" : "client secret");
 		OAuth2ServiceEndpointsProvider endpointsProvider = new XsuaaDefaultEndpoints(xsuaaConfig);
 		ClientIdentity clientIdentity = xsuaaConfig.getClientIdentity();
-		OAuth2TokenService oAuth2TokenService = new DefaultOAuth2TokenService(httpClient);
+		OAuth2TokenService oAuth2TokenService = new DefaultOAuth2TokenService(httpClient,
+				TokenCacheConfiguration.defaultConfiguration(),
+				SpringTokenClientConfiguration.getInstance());
 		return new XsuaaTokenFlows(oAuth2TokenService, endpointsProvider, clientIdentity);
 	}
 

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenService.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenService.java
@@ -10,6 +10,7 @@ import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.*;
 import static org.apache.http.HttpHeaders.USER_AGENT;
 
 import com.sap.cloud.security.client.DefaultTokenClientConfiguration;
+import com.sap.cloud.security.client.TokenClientConfiguration;
 import com.sap.cloud.security.servlet.MDCHelper;
 import com.sap.cloud.security.xsuaa.Assertions;
 import com.sap.cloud.security.xsuaa.http.HttpHeaders;
@@ -39,19 +40,26 @@ public class DefaultOAuth2TokenService extends AbstractOAuth2TokenService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultOAuth2TokenService.class);
   private final CloseableHttpClient httpClient;
-  private final DefaultTokenClientConfiguration config;
+  private final TokenClientConfiguration config;
 
   public DefaultOAuth2TokenService(@Nonnull final CloseableHttpClient httpClient) {
     this(httpClient, TokenCacheConfiguration.defaultConfiguration());
   }
 
   public DefaultOAuth2TokenService(
-      @Nonnull final CloseableHttpClient httpClient,
-      @Nonnull final TokenCacheConfiguration tokenCacheConfiguration) {
+          @Nonnull final CloseableHttpClient httpClient,
+          @Nonnull final TokenCacheConfiguration tokenCacheConfiguration) {
+    this(httpClient, tokenCacheConfiguration, DefaultTokenClientConfiguration.getInstance());
+  }
+
+  public DefaultOAuth2TokenService(
+          @Nonnull final CloseableHttpClient httpClient,
+          @Nonnull final TokenCacheConfiguration tokenCacheConfiguration,
+          @Nonnull final TokenClientConfiguration tokenClientConfiguration) {
     super(tokenCacheConfiguration);
     Assertions.assertNotNull(httpClient, "http client is required");
     this.httpClient = httpClient;
-    this.config = DefaultTokenClientConfiguration.getInstance();
+    this.config = tokenClientConfiguration;
   }
 
   @Override


### PR DESCRIPTION
The DefaultOAuth2TokenService is used for Jakarta and Spring but the Retry feature was always configured with the non-Spring configuration.