### PR TITLE
Improve error message when client certificate is missing

### DIFF
--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidator.java
@@ -75,7 +75,7 @@ class SapIdJwtSignatureValidator extends JwtSignatureValidator {
 			X509Certificate cert = (X509Certificate) SecurityContext.getClientCertificate();
 
 			if (cert == null) {
-				throw new OAuth2ServiceException("Proof token was not found");
+				throw new OAuth2ServiceException("Client certificate for proof token validation could not be read from 'x-forwarded-client-cert' header.");
 			} else {
 				Map<String, String> cacheKeyParams = new HashMap<>(requestParams);
 

--- a/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidatorTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidatorTest.java
@@ -194,7 +194,11 @@ public class SapIdJwtSignatureValidatorTest {
 				OidcConfigurationServiceWithCache.getInstance()
 						.withOidcConfigurationService(oidcConfigServiceMock));
 		cut.enableProofTokenValidationCheck();
-		assertTrue(cut.validate(iasToken).isErroneous());
+		ValidationResult validationResult = cut.validate(iasToken);
+		assertTrue(validationResult.isErroneous());
+		assertThat(validationResult.getErrorDescription(),
+				containsString(
+						"Token signature can not be validated because JWKS could not be fetched: Client certificate for proof token validation could not be read from 'x-forwarded-client-cert' header."));
 	}
 
 	@Test


### PR DESCRIPTION
The old message was misleading since it is not the proof token that is missing in this case but the client certificate.