### PR TITLE
Bump spring.security.version from 6.4.5 to 6.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 		<!-- make sure that spring core and spring boot versions are compatible-->
 		<spring.boot.version>3.5.0</spring.boot.version>
 		<spring.core.version>6.2.7</spring.core.version>
-		<spring.security.version>6.4.5</spring.security.version>
+		<spring.security.version>6.5.0</spring.security.version>
 		<spring.security.oauth2.version>2.5.2.RELEASE</spring.security.oauth2.version>
 		<spring.security.jwt.version>1.1.1.RELEASE</spring.security.jwt.version>
 		<org.eclipse.jetty.version>12.0.22</org.eclipse.jetty.version>

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
@@ -130,13 +130,8 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 
 			return verifyToken(jwt.getParsedString(), kid, uaaDomain, getZid(jwt));
 		} catch (JwtException e) {
-			if (e.getMessage().contains("Couldn't retrieve remote JWK set")
-					|| e.getMessage().contains("Cannot verify with online token key, uaadomain is")) {
-				logger.error(e.getMessage());
-				return tryToVerifyWithVerificationKey(jwt.getParsedString(), e);
-			} else {
-				throw e;
-			}
+			logger.error(e.getMessage());
+			return tryToVerifyWithVerificationKey(jwt.getParsedString(), e);
 		}
 	}
 


### PR DESCRIPTION
Bumping spring security version and fixing verification key fallback to no longer depend on exception messages.