### PR TITLE
SCICAS-3575 Improve logging before token key retrieval fallback

### DIFF
--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/XsuaaJwtSignatureValidator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/XsuaaJwtSignatureValidator.java
@@ -59,8 +59,10 @@ class XsuaaJwtSignatureValidator extends JwtSignatureValidator {
 			key = fetchPublicKey(token, algorithm);
 		} catch (OAuth2ServiceException | InvalidKeySpecException | NoSuchAlgorithmException
 				| IllegalArgumentException e) {
-			if (!configuration.hasProperty(ServiceConstants.XSUAA.VERIFICATION_KEY)) {
+			if (!configuration.isLegacyMode()) {
 				LOGGER.error("Error fetching public key from XSUAA service: {}", e.getMessage());
+			}
+			if (!configuration.hasProperty(ServiceConstants.XSUAA.VERIFICATION_KEY)) {
 				throw e;
 			}
 


### PR DESCRIPTION
To reduce log spamming in the legacy XSA case, we recently started to skip the logging of errors during token key retrieval. The error then was only logged if there was no verification key available for the fallback.

However, there are non-legacy cases, where a verification key is available. In these cases the new logic swallowed the error log. To improve the situation, we now only skip the error log if we are in the legacy mode.