### PR TITLE
Release 3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 3.6.2
+
+- Improve logging before token key retrieval fallback
+- remove repository config for old sonatype plugin
+- added version references to POMs and other minor informations
+- Update README.md for using correct path to SpringTokenClientConfigura…
+- Maven central preparation
+
+### Dependency upgrades
+
+- Bump com.github.spotbugs:spotbugs-maven-plugin from 4.9.3.1 to 4.9.3.2
+- Bump io.github.hakky54:logcaptor from 2.11.0 to 2.12.0
+- Bump org.eclipse.jetty.version from 12.0.22 to 12.0.24
+- Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.7 to 3.2.8
+- Bump log4j2.version from 2.25.0 to 2.25.1
+- Bump commons-io:commons-io from 2.19.0 to 2.20.0
+- Bump reactor.version from 3.7.7 to 3.7.8
+- Bump spring.core.version from 6.2.8 to 6.2.9
+- Bump spring.security.version from 6.5.1 to 6.5.2
+- Bump spring.boot.version from 3.5.3 to 3.5.4
+- Bump com.github.spotbugs:spotbugs-maven-plugin from 4.9.3.0 to 4.9.3.1
+- Bump org.apache.maven.plugins:maven-pmd-plugin from 3.26.0 to 3.27.0
+- Bump spring.security.version from 6.5.0 to 6.5.1
+- Bump spring.boot.version from 3.5.0 to 3.5.3
+
 ## 3.6.1
 
 - Fix spring retry configuration for token service
@@ -9,22 +34,22 @@ All notable changes to this project will be documented in this file.
 
 ### Dependency upgrades
 
-Bump org.eclipse.jetty.version from 12.0.21 to 12.0.22
-bump caffeine version to 3.2.0
-Bump org.mockito:mockito-core from 5.17.0 to 5.18.0
-Bump org.apache.httpcomponents.client5:httpclient5 from 5.4.4 to 5.5
-Bump com.sap.cloud.environment.servicebinding:java-bom
-Bump org.json:json from 20250107 to 20250517
-Bump commons-io:commons-io from 2.18.0 to 2.19.0
-Bump spring.core.version from 6.2.5 to 6.2.7
-Bump io.github.hakky54:logcaptor from 2.10.2 to 2.11.0
-Bump spring.security.version from 6.4.4 to 6.4.5
-Bump org.apache.httpcomponents.client5:httpclient5 from 5.4.3 to 5.4.4
-Bump spring.boot.version from 3.4.4 to 3.4.5
-Bump org.wiremock:wiremock-standalone from 3.12.1 to 3.13.0
-Bump org.eclipse.jetty.version from 12.0.19 to 12.0.21
-Bump io.projectreactor:reactor-test from 3.7.4 to 3.7.6
-Bump io.projectreactor:reactor-core from 3.7.4 to 3.7.6
+- Bump org.eclipse.jetty.version from 12.0.21 to 12.0.22
+- bump caffeine version to 3.2.0
+- Bump org.mockito:mockito-core from 5.17.0 to 5.18.0
+- Bump org.apache.httpcomponents.client5:httpclient5 from 5.4.4 to 5.5
+- Bump com.sap.cloud.environment.servicebinding:java-bom
+- Bump org.json:json from 20250107 to 20250517
+- Bump commons-io:commons-io from 2.18.0 to 2.19.0
+- Bump spring.core.version from 6.2.5 to 6.2.7
+- Bump io.github.hakky54:logcaptor from 2.10.2 to 2.11.0
+- Bump spring.security.version from 6.4.4 to 6.4.5
+- Bump org.apache.httpcomponents.client5:httpclient5 from 5.4.3 to 5.4.4
+- Bump spring.boot.version from 3.4.4 to 3.4.5
+- Bump org.wiremock:wiremock-standalone from 3.12.1 to 3.13.0
+- Bump org.eclipse.jetty.version from 12.0.19 to 12.0.21
+- Bump io.projectreactor:reactor-test from 3.7.4 to 3.7.6
+- Bump io.projectreactor:reactor-core from 3.7.4 to 3.7.6
 
 ## 3.6.0
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The SAP Cloud Security Services Integration is published to maven central: https
         <dependency>
             <groupId>com.sap.cloud.security</groupId>
             <artifactId>java-bom</artifactId>
-            <version>3.6.1</version>
+            <version>3.6.2</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-bom</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
     <packaging>pom</packaging>
     <name>java-bom</name>
 

--- a/env/pom.xml
+++ b/env/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
         <artifactId>parent</artifactId>
-        <version>3.6.1</version>
+        <version>3.6.2</version>
     </parent>
 
     <groupId>com.sap.cloud.security</groupId>

--- a/java-api/README.md
+++ b/java-api/README.md
@@ -5,6 +5,6 @@
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-api</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
 </dependency>
 ```

--- a/java-api/pom.xml
+++ b/java-api/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.1</version>
+		<version>3.6.2</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security-it/pom.xml
+++ b/java-security-it/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
-        <version>3.6.1</version>
+        <version>3.6.2</version>
     </parent>
 
     <artifactId>java-security-it</artifactId>

--- a/java-security-test/README.md
+++ b/java-security-test/README.md
@@ -40,7 +40,7 @@ It is pre-configured with a security filter that only accepts valid tokens. Furt
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
    <artifactId>java-security-test</artifactId>
-      <version>3.6.1</version>
+      <version>3.6.2</version>
    <scope>test</scope>
 </dependency>
 ```

--- a/java-security-test/pom.xml
+++ b/java-security-test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.1</version>
+		<version>3.6.2</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security/README.md
+++ b/java-security/README.md
@@ -68,7 +68,7 @@ Since it requires the Tomcat 10 runtime, it needs to be deployed using the [SAP 
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-security</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/java-security/pom.xml
+++ b/java-security/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.1</version>
+		<version>3.6.2</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>com.sap.cloud.security.xsuaa</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.6.1</version>
+	<version>3.6.2</version>
 	<packaging>pom</packaging>
 
 	<name>parent</name>

--- a/samples/java-security-usage-ias/pom.xml
+++ b/samples/java-security-usage-ias/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-security-usage-ias</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
     <packaging>war</packaging>
 
     <url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
@@ -43,7 +43,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <sap.cloud.security.version>3.6.1</sap.cloud.security.version>
+        <sap.cloud.security.version>3.6.2</sap.cloud.security.version>
         <slf4j.api.version>2.0.5</slf4j.api.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>

--- a/samples/java-security-usage/pom.xml
+++ b/samples/java-security-usage/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-security-usage</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
     <packaging>war</packaging>
 
     <!--profiles>
@@ -58,7 +58,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <sap.cloud.security.version>3.6.1</sap.cloud.security.version>
+        <sap.cloud.security.version>3.6.2</sap.cloud.security.version>
         <slf4j.api.version>2.0.5</slf4j.api.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>

--- a/samples/java-tokenclient-usage/pom.xml
+++ b/samples/java-tokenclient-usage/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-tokenclient-usage</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
     <packaging>war</packaging>
 
     <url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
@@ -42,7 +42,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <sap.cloud.security.version>3.6.1</sap.cloud.security.version>
+        <sap.cloud.security.version>3.6.2</sap.cloud.security.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>
         <slf4j.api.version>2.0.5</slf4j.api.version>

--- a/samples/sap-java-buildpack-api-usage/pom.xml
+++ b/samples/sap-java-buildpack-api-usage/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.sap.cloud.security.xssec.samples</groupId>
 	<artifactId>sap-java-buildpack-api-usage</artifactId>
-	<version>3.6.1</version>
+	<version>3.6.2</version>
 	<packaging>war</packaging>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>

--- a/samples/spring-security-basic-auth/pom.xml
+++ b/samples/spring-security-basic-auth/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 
 	<artifactId>spring-security-basic-auth</artifactId>
-	<version>3.6.1</version>
+	<version>3.6.2</version>
 	<name>spring-security-basic-auth</name>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
@@ -51,7 +51,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<sap.cloud.security.version>3.6.1</sap.cloud.security.version>
+		<sap.cloud.security.version>3.6.2</sap.cloud.security.version>
 		<spring.boot.version>3.5.3</spring.boot.version>
 	</properties>
 
@@ -109,7 +109,7 @@
 		<dependency>
 			<groupId>com.sap.cloud.security</groupId>
 			<artifactId>java-security-test</artifactId>
-			<version>3.6.1</version>
+			<version>3.6.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/samples/spring-security-hybrid-usage/pom.xml
+++ b/samples/spring-security-hybrid-usage/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.sap.cloud.security.samples</groupId>
 	<artifactId>spring-security-hybrid-usage</artifactId>
-	<version>3.6.1</version>
+	<version>3.6.2</version>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
 	<description>Java Spring security hybrid usage sample</description>
@@ -58,7 +58,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<sap.cloud.security.version>3.6.1</sap.cloud.security.version>
+		<sap.cloud.security.version>3.6.2</sap.cloud.security.version>
 		<apache.httpclient.version>4.5.14</apache.httpclient.version>
 		<spring.boot.version>3.5.3</spring.boot.version>
 	</properties>

--- a/samples/spring-security-xsuaa-usage/pom.xml
+++ b/samples/spring-security-xsuaa-usage/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.sap.cloud.security.samples</groupId>
 	<artifactId>spring-security-xsuaa-usage</artifactId>
-	<version>3.6.1</version>
+	<version>3.6.2</version>
 	<name>spring-security-xsuaa-usage</name>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
@@ -59,7 +59,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<sap.cloud.security.version>3.6.1</sap.cloud.security.version>
+		<sap.cloud.security.version>3.6.2</sap.cloud.security.version>
 		<http.client5>5.2.1</http.client5>
 		<spring.boot.version>3.5.3</spring.boot.version>
 	</properties>

--- a/samples/spring-webflux-security-hybrid-usage/pom.xml
+++ b/samples/spring-webflux-security-hybrid-usage/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.sap.cloud.security.samples</groupId>
     <artifactId>spring-webflux-security-hybrid-usage</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
     <name>spring-webflux-security-hybrid-usage</name>
 
     <url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
@@ -49,7 +49,7 @@
     </scm>
     <properties>
         <java.version>17</java.version>
-        <sap.cloud.security.version>3.6.1</sap.cloud.security.version>
+        <sap.cloud.security.version>3.6.2</sap.cloud.security.version>
         <spring.boot.version>3.5.3</spring.boot.version>
         <junit.version>4.13.2</junit.version>
     </properties>

--- a/spring-security-compatibility/pom.xml
+++ b/spring-security-compatibility/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
         <artifactId>parent</artifactId>
-        <version>3.6.1</version>
+        <version>3.6.2</version>
     </parent>
 
     <groupId>com.sap.cloud.security.xsuaa</groupId>

--- a/spring-security-starter/pom.xml
+++ b/spring-security-starter/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.1</version>
+		<version>3.6.2</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/spring-security/Migration_SpringXsuaaProjects.md
+++ b/spring-security/Migration_SpringXsuaaProjects.md
@@ -157,7 +157,7 @@ It is provided in an extra module. This maven dependency needs to be provided ad
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-security-compatibility</artifactId>
-  <version>3.6.1</version>
+  <version>3.6.2</version>
 </dependency>
 ```
 

--- a/spring-security/README.md
+++ b/spring-security/README.md
@@ -67,7 +67,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-starter</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
 </dependency>
 ```
 

--- a/spring-security/pom.xml
+++ b/spring-security/pom.xml
@@ -9,14 +9,14 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.1</version>
+		<version>3.6.2</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>
 	<artifactId>spring-security</artifactId>
 	<name>spring-security</name>
 	<packaging>jar</packaging>
-	<version>3.6.1</version>
+	<version>3.6.2</version>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
 	<description>Java Spring security library</description>

--- a/spring-xsuaa-it/pom.xml
+++ b/spring-xsuaa-it/pom.xml
@@ -14,7 +14,7 @@
 
 	<artifactId>spring-xsuaa-it</artifactId>
 	<name>spring-xsuaa-it</name>
-	<version>3.6.1</version>
+	<version>3.6.2</version>
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
 	<description>Java Spring XSUAA IT library</description>
 
@@ -49,7 +49,7 @@
 	<properties>
 		<mockwebserver.version>4.10.0</mockwebserver.version>
 		<java.version>17</java.version>
-		<sap.cloud.security.version>3.6.1</sap.cloud.security.version>
+		<sap.cloud.security.version>3.6.2</sap.cloud.security.version>
 		<spring.boot.version>3.5.3</spring.boot.version>
 	</properties>
 

--- a/spring-xsuaa-starter/pom.xml
+++ b/spring-xsuaa-starter/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.1</version>
+		<version>3.6.2</version>
 	</parent>
 
 	<artifactId>xsuaa-spring-boot-starter</artifactId>

--- a/spring-xsuaa-test/README.md
+++ b/spring-xsuaa-test/README.md
@@ -31,7 +31,7 @@ This includes for example a `JwtGenerator` that generates JSON Web Tokens (JWT) 
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-xsuaa-test</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
     <scope>test</scope>
 </dependency>
 

--- a/spring-xsuaa-test/pom.xml
+++ b/spring-xsuaa-test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.1</version>
+		<version>3.6.2</version>
 	</parent>
 
 	<artifactId>spring-xsuaa-test</artifactId>

--- a/spring-xsuaa/README.md
+++ b/spring-xsuaa/README.md
@@ -39,7 +39,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-xsuaa</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
 </dependency>
 <dependency> <!-- new with version 1.5.0 -->
     <groupId>org.apache.logging.log4j</groupId>
@@ -53,7 +53,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>xsuaa-spring-boot-starter</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
 </dependency>
 ```
 

--- a/spring-xsuaa/pom.xml
+++ b/spring-xsuaa/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.1</version>
+		<version>3.6.2</version>
 	</parent>
 
 	<artifactId>spring-xsuaa</artifactId>

--- a/token-client/README.md
+++ b/token-client/README.md
@@ -52,7 +52,7 @@ In context of a Spring Boot application you can leverage autoconfiguration provi
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-starter</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
 </dependency>
 ```
 In context of Spring Applications you will need the following dependencies:
@@ -60,7 +60,7 @@ In context of Spring Applications you will need the following dependencies:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>
@@ -127,7 +127,7 @@ See the [OAuth2ServiceConfiguration](#oauth2serviceconfiguration) section and [H
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/token-client/pom.xml
+++ b/token-client/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.1</version>
+		<version>3.6.2</version>
 	</parent>
 
 	<artifactId>token-client</artifactId>


### PR DESCRIPTION
- Improve logging before token key retrieval fallback
- remove repository config for old sonatype plugin
- added version references to POMs and other minor informations
- Update README.md for using correct path to SpringTokenClientConfigura…
- Maven central preparation

### Dependency upgrades

- Bump com.github.spotbugs:spotbugs-maven-plugin from 4.9.3.1 to 4.9.3.2
- Bump io.github.hakky54:logcaptor from 2.11.0 to 2.12.0
- Bump org.eclipse.jetty.version from 12.0.22 to 12.0.24
- Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.7 to 3.2.8
- Bump log4j2.version from 2.25.0 to 2.25.1
- Bump commons-io:commons-io from 2.19.0 to 2.20.0
- Bump reactor.version from 3.7.7 to 3.7.8
- Bump spring.core.version from 6.2.8 to 6.2.9
- Bump spring.security.version from 6.5.1 to 6.5.2
- Bump spring.boot.version from 3.5.3 to 3.5.4
- Bump com.github.spotbugs:spotbugs-maven-plugin from 4.9.3.0 to 4.9.3.1
- Bump org.apache.maven.plugins:maven-pmd-plugin from 3.26.0 to 3.27.0
- Bump spring.security.version from 6.5.0 to 6.5.1
- Bump spring.boot.version from 3.5.0 to 3.5.3
