### PR TITLE
Update jetty dependency to 12.0.27

### DIFF
--- a/java-security-test/pom.xml
+++ b/java-security-test/pom.xml
@@ -70,11 +70,6 @@
 			<version>${jakarta.servlet.api.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-server</artifactId>
-			<version>${org.eclipse.jetty.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>org.eclipse.jetty.ee10</groupId>
 			<artifactId>jetty-ee10-servlet</artifactId>
 			<version>${org.eclipse.jetty.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 		<spring.security.oauth2.version>6.5.5</spring.security.oauth2.version>
 		<spring.security.version>6.5.5</spring.security.version>
 		<spring.security.jwt.version>1.1.1.RELEASE</spring.security.jwt.version>
-		<org.eclipse.jetty.version>12.0.24</org.eclipse.jetty.version>
+		<org.eclipse.jetty.version>12.0.27</org.eclipse.jetty.version>
 		<reactor.version>3.7.11</reactor.version>
 		<log4j2.version>2.25.2</log4j2.version>
 		<slf4j.api.version>2.0.17</slf4j.api.version> <!--see also here http://www.slf4j.org/faq.html#changesInVersion18 -->


### PR DESCRIPTION
This includes the removal of a duplicate dependency to a depreceated location of the server module.